### PR TITLE
! Fixed out of bounds access on gamepadweapons.

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -347,7 +347,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
 
     if (!idclev && !idmus)
     {
-        for (i = 0; i < NUMWEAPONS - 1; i++)
+        for (i = 0; i < (sizeof(gamepadweapons)/sizeof(gamepadweapons[0])) - 1; i++)
         {
             int key = *weapon_keys[i];
 


### PR DESCRIPTION
Starting doom 1 crashed on an oob for me as NUMWEAPONS is 9 and gamepadweapons is 7, might want to consider this fix (not too familiar with the code so let me know if this fix breaks anything).
