### PR TITLE
OSX: Save user files into Application Support instead of app location.

### DIFF
--- a/src/c_cmds.c
+++ b/src/c_cmds.c
@@ -931,19 +931,21 @@ static void condump_cmd_func2(char *cmd, char *parm1, char *parm2, char *parm3)
     {
         char    filename[MAX_PATH];
         FILE    *file;
-        char    *exefolder = M_GetExecutableFolder();
+        const char *appdatafolder = M_GetAppDataFolder();
 
+        M_MakeDirectory(appdatafolder);
+        
         if (!parm1[0])
         {
             int count = 0;
 
-            M_snprintf(filename, sizeof(filename), "%s"DIR_SEPARATOR_S"condump.txt", exefolder);
+            M_snprintf(filename, sizeof(filename), "%s"DIR_SEPARATOR_S"condump.txt", appdatafolder);
             while (M_FileExists(filename))
                 M_snprintf(filename, sizeof(filename), "%s"DIR_SEPARATOR_S"condump (%i).txt",
-                    exefolder, ++count);
+                    appdatafolder, ++count);
         }
         else
-            M_snprintf(filename, sizeof(filename), "%s"DIR_SEPARATOR_S"%s", exefolder, parm1);
+            M_snprintf(filename, sizeof(filename), "%s"DIR_SEPARATOR_S"%s", appdatafolder, parm1);
 
         file = fopen(filename, "wt");
 

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -539,7 +539,10 @@ void D_SetSaveGameFolder(void)
     if (!iwad_name)
         iwad_name = "unknown.wad";
 
-    savegamefolder = M_StringJoin(M_GetExecutableFolder(), DIR_SEPARATOR_S, "savegames",
+    const char *appdatafolder = M_GetAppDataFolder();
+    M_MakeDirectory(appdatafolder);
+    
+    savegamefolder = M_StringJoin(appdatafolder, DIR_SEPARATOR_S, "savegames",
         DIR_SEPARATOR_S, NULL);
     M_MakeDirectory(savegamefolder);
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -6,8 +6,8 @@
 
 ========================================================================
 
-  Copyright � 1993-2012 id Software LLC, a ZeniMax Media company.
-  Copyright � 2013-2016 Brad Harding.
+  Copyright © 1993-2012 id Software LLC, a ZeniMax Media company.
+  Copyright © 2013-2016 Brad Harding.
 
   DOOM Retro is a fork of Chocolate DOOM.
   For a list of credits, see the accompanying AUTHORS file.

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -6,8 +6,8 @@
 
 ========================================================================
 
-  Copyright © 1993-2012 id Software LLC, a ZeniMax Media company.
-  Copyright © 2013-2016 Brad Harding.
+  Copyright ï¿½ 1993-2012 id Software LLC, a ZeniMax Media company.
+  Copyright ï¿½ 2013-2016 Brad Harding.
 
   DOOM Retro is a fork of Chocolate DOOM.
   For a list of credits, see the accompanying AUTHORS file.
@@ -940,7 +940,7 @@ static int D_ChooseIWAD(void)
                             iwadfound = 1;
                             sharewareiwad = M_StringCompare(iwadpass, "DOOM1.WAD");
                             isDOOM2 = M_StringCompare(iwadpass, "DOOM2.WAD");
-                            iwadfolder = strdup(fullpath);
+                            iwadfolder = strdup(M_ExtractFolder(fullpath));
                             break;
                         }
                     }

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1257,10 +1257,13 @@ static void D_DoomMainSetup(void)
     int         p;
     int         choseniwad = 0;
     static char lumpname[6];
-    char        *exefolder = M_GetExecutableFolder();
-    char        *packagewad = M_StringJoin(exefolder, DIR_SEPARATOR_S, PACKAGE_WAD, NULL);
+    const char  *resourcefolder = M_GetResourceFolder();
+    const char  *appdatafolder = M_GetAppDataFolder();
+    const char  *packagewad = M_StringJoin(resourcefolder, DIR_SEPARATOR_S, PACKAGE_WAD, NULL);
+    
+    M_MakeDirectory(appdatafolder);
 
-    packageconfig = M_StringJoin(exefolder, DIR_SEPARATOR_S, PACKAGE_CONFIG, NULL);
+    packageconfig = M_StringJoin(appdatafolder, DIR_SEPARATOR_S, PACKAGE_CONFIG, NULL);
 
     C_Output("");
     C_PrintCompileDate();
@@ -1317,14 +1320,7 @@ static void D_DoomMainSetup(void)
     else
         C_Output("~"PACKAGE_NAME"~ has been run %s times.", commify(SafeAdd(stat_runs, 1)));
 
-#if !defined(__MACOSX__)
     if (!M_FileExists(packagewad))
-#else
-    NSString *packageWadFullpath =
-        [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@PACKAGE_WAD];
-
-    if (!M_FileExists((char *)[packageWadFullpath UTF8String]))
-#endif
         I_Error("%s can't be found.\nPlease reinstall " PACKAGE_NAME ".", uppercase(packagewad));
 
     p = M_CheckParmsWithArgs("-file", "-pwad", 1, 1);
@@ -1379,11 +1375,7 @@ static void D_DoomMainSetup(void)
         I_Error("Game mode indeterminate. No IWAD file was found. Try\n"
                 "specifying one with the '-iwad' command-line parameter.");
 
-#if !defined(__MACOSX__)
     if (!W_MergeFile(packagewad, true))
-#else
-    if (!W_MergeFile((char*)[packageWadFullpath UTF8String], true))
-#endif
         I_Error("%s can't be found.\nPlease reinstall "PACKAGE_NAME".", uppercase(packagewad));
 
     if (!CheckPackageWADVersion())

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -6,8 +6,8 @@
 
 ========================================================================
 
-  Copyright � 1993-2012 id Software LLC, a ZeniMax Media company.
-  Copyright � 2013-2016 Brad Harding.
+  Copyright © 1993-2012 id Software LLC, a ZeniMax Media company.
+  Copyright © 2013-2016 Brad Harding.
 
   DOOM Retro is a fork of Chocolate DOOM.
   For a list of credits, see the accompanying AUTHORS file.

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -6,8 +6,8 @@
 
 ========================================================================
 
-  Copyright © 1993-2012 id Software LLC, a ZeniMax Media company.
-  Copyright © 2013-2016 Brad Harding.
+  Copyright ï¿½ 1993-2012 id Software LLC, a ZeniMax Media company.
+  Copyright ï¿½ 2013-2016 Brad Harding.
 
   DOOM Retro is a fork of Chocolate DOOM.
   For a list of credits, see the accompanying AUTHORS file.
@@ -142,7 +142,7 @@ char *M_ExtractFolder(char *path)
 
     M_StringCopy(folder, path, MAX_PATH);
 
-    pos = strrchr(folder, '\\');
+    pos = strrchr(folder, DIR_SEPARATOR);
     if (pos)
         *pos = '\0';
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -56,6 +56,11 @@
 #include "i_system.h"
 #include "z_zone.h"
 
+#if defined(__MACOSX__)
+#include "version.h"
+#import <Cocoa/Cocoa.h>
+#endif
+
 #if !defined(MAX_PATH)
 #define MAX_PATH        260
 #endif
@@ -63,7 +68,7 @@
 //
 // Create a directory
 //
-void M_MakeDirectory(char *path)
+void M_MakeDirectory(const char *path)
 {
 #if defined(WIN32)
     mkdir(path);
@@ -73,7 +78,7 @@ void M_MakeDirectory(char *path)
 }
 
 // Check if a file exists
-dboolean M_FileExists(char *filename)
+dboolean M_FileExists(const char *filename)
 {
     FILE        *fstream;
 
@@ -144,6 +149,34 @@ char *M_ExtractFolder(char *path)
     return folder;
 }
 
+const char *M_GetAppDataFolder(void)
+{
+    //On OSX, store generated application files in ~/Library/Application Support/DOOM Retro.
+#if defined(__MACOSX__)
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSURL *baseAppSupportURL = [manager URLsForDirectory: NSApplicationSupportDirectory inDomains: NSUserDomainMask].firstObject;
+    NSURL *appSupportURL = [baseAppSupportURL URLByAppendingPathComponent: @PACKAGE_NAME];
+    return appSupportURL.fileSystemRepresentation;
+#else
+    //On Windows and Linux, store generated files in the same folder as the executable.
+    //TODO: on Windows this should probably use %APPDATA%/PACKAGE_NAME,
+    //and on Unix it should probably use somewhere within ~.
+    return M_GetExecutableFolder();
+#endif
+}
+
+const char *M_GetResourceFolder(void)
+{
+#if defined(__MACOSX__)
+    //On OSX, load resources from the Contents/Resources folder within the application bundle.
+    NSURL *resourceURL = [NSBundle mainBundle].resourceURL;
+    return resourceURL.fileSystemRepresentation;
+#else
+    //On Windows and Linux, load resources from the same folder as the executable.
+    return M_GetExecutableFolder();
+#endif
+}
+
 char *M_GetExecutableFolder(void)
 {
 #if defined(WIN32)
@@ -158,6 +191,13 @@ char *M_GetExecutableFolder(void)
     if (pos)
         *pos = '\0';
 
+    //FIXME: the string returned here is allocated on the heap,
+    //but that is inconsistent with the non-windows branch below
+    //and no caller of this method bothers to free the returned
+    //string anyway.
+    //Instead this method should return an address on the stack,
+    //and make it the caller's responsibility to copy the string
+    //if it's needed beyond the stack scope.
     return folder;
 #else
     return ".";
@@ -219,7 +259,7 @@ int M_ReadFile(char *name, byte **buffer)
 
 // Return a newly-malloced string with all the strings given as arguments
 // concatenated together.
-char *M_StringJoin(char *s, ...)
+char *M_StringJoin(const char *s, ...)
 {
     char *result, *v;
     va_list args;

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -46,17 +46,29 @@
 
 dboolean M_WriteFile(char *name, void *source, int length);
 int M_ReadFile(char *name, byte **buffer);
-void M_MakeDirectory(char *dir);
+void M_MakeDirectory(const char *dir);
 char *M_TempFile(char *s);
-dboolean M_FileExists(char *file);
+dboolean M_FileExists(const char *file);
 long M_FileLength(FILE *handle);
 char *M_ExtractFolder(char *path);
+
+/// Returns the filesystem location where application resource files are located.
+/// On Windows and Linux, this is the folder in which doomretro.exe is located;
+/// on OSX, this is the Contents/Resources folder within the application bundle.
+const char *M_GetResourceFolder(void);
+
+/// Returns the filesystem location where generated application
+/// data (configuration files, logs, savegames etc.) should be saved.
+/// On Windows and Linux, this is the folder in which doomretro.exe is located;
+/// on OSX, this is ~/Library/Application Support/DOOM Retro/.
+const char *M_GetAppDataFolder(void);
+
 char *M_GetExecutableFolder(void);
 dboolean M_StrToInt(const char *str, int *result);
 char *M_StrCaseStr(char *haystack, char *needle);
 dboolean M_StringCopy(char *dest, char *src, size_t dest_size);
 char *M_StringReplace(char *haystack, char *needle, char *replacement);
-char *M_StringJoin(char *s, ...);
+char *M_StringJoin(const char *s, ...);
 dboolean M_StringStartsWith(char *s, char *prefix);
 dboolean M_StringEndsWith(char *s, char *suffix);
 int M_vsnprintf(char *buf, size_t buf_len, const char *s, va_list args);


### PR DESCRIPTION
This pull request makes DR save its user-generated files (configs, logs, savegames) into the appropriate per-user Application Support folder on OSX, rather than saving them to the folder the app is located in. It also adds a suitable hook for Windows and Linux builds to do the same: e.g. Windows ought to save to "%APPDATA%\Doom Retro", while Linux should probably save to "~/.doomretro". (I have not changed the behaviour for those platforms though.)

This behaviour is necessary because OSX apps are not kept in folders of their own - they are self-contained bundles that are typically stored in a single Applications folder alongside many other apps. Rather than write to their location, apps are expected to write to specific per-user folders - and indeed the app's containing folder may be read-only, so writes to it would fail.

The pull request also contains a fix for an iwad folder resolution bug that affected OSX. I've also noted a memory leak in DR's file path handling on Windows, though I haven't fixed it.