### PR TITLE
Removed warnings (gcc 5.3.0)

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1471,11 +1471,11 @@ static void D_DoomMainSetup(void)
         {
             char *skilllevels[] =
             {
-                { "I\'m too young to die" },
-                { "Hey, not too rough"    },
-                { "Hurt me plenty"        },
-                { "Ultra-Violence"        },
-                { "Nightmare"             }
+                "I\'m too young to die",
+                "Hey, not too rough",
+                "Hurt me plenty",
+                "Ultra-Violence",
+                "Nightmare"             
             };
 
             skilllevel = startskill = (skill_t)temp;
@@ -1495,10 +1495,10 @@ static void D_DoomMainSetup(void)
         {
             char *episodes[] =
             {
-                { "Knee-Deep in the Dead" },
-                { "The Shores of Hell"    },
-                { "Inferno"               },
-                { "Thy Flesh Consumed"    }
+                "Knee-Deep in the Dead",
+                "The Shores of Hell",
+                "Inferno",
+                "Thy Flesh Consumed"
             };
 
             startepisode = temp;
@@ -1524,8 +1524,8 @@ static void D_DoomMainSetup(void)
         {
             char *expansions[] =
             {
-                { "Hell on Earth"          },
-                { "No Rest for the Living" }
+                "Hell on Earth",
+                "No Rest for the Living"
             };
 
             gamemission = (temp == 1 ? doom2 : pack_nerve);

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -247,6 +247,8 @@ void I_ShutdownWindows32(void)
 }
 #endif
 
+void D_DoomMain(void);
+
 int main(int argc, char **argv)
 {
 #if defined(WIN32)

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -289,7 +289,7 @@ void R_DrawColumnInCache(const column_t *patch, byte *cache, int originy, int ca
 static void R_GenerateComposite(int texnum)
 {
     byte                *block = Z_Calloc(1, texturecompositesize[texnum], PU_STATIC,
-                            &texturecomposite[texnum]);
+                            (void **) &texturecomposite[texnum]);
     texture_t           *texture = textures[texnum];
 
     short               width = texture->width;
@@ -381,8 +381,8 @@ void R_GenerateLookup(int texnum)
     texture_t           *texture = textures[texnum];
     short               width = texture->width;
     short               height = texture->height;
-    byte                *patchcount = (byte *)Z_Malloc(width, PU_STATIC, &patchcount);
-    byte                *postcount = (byte *)Z_Malloc(width, PU_STATIC, &postcount);
+    byte                *patchcount = (byte *)Z_Malloc(width, PU_STATIC, (void **) &patchcount);
+    byte                *postcount = (byte *)Z_Malloc(width, PU_STATIC, (void **) &postcount);
     texpatch_t          *patch;
     int                 x;
     int                 i;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -320,7 +320,7 @@ void R_InitSprites(char **namelist)
     for (i = 0; i < SCREENWIDTH; i++)
         negonearray[i] = -1;
 
-    R_InitSpriteDefs(namelist);
+    R_InitSpriteDefs((const char * const*) namelist);
 
     num_vissprite = 0;
     num_vissprite_alloc = 128;


### PR DESCRIPTION
I've removed all warnings I get during compilation by removing some unecessary brackets and by adding one forward declaration and some trivial casts.

(2nd try. Sorry about that.)