### PR TITLE
fix a few issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@
 
 OPTFLAGS = -O2
 CFLAGS = $(OPTFLAGS) -g `sdl2-config --cflags`
-LDFLAGS = -g `sdl2-config --libs` -lSDL2_mixer -lm
+LDFLAGS = -g `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lm
 
 # If you don't want to compile with X11 bindings,
 # set the NOX11 variable, e.g. make NOX11=1

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -59,6 +59,10 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
+#if defined(__OpenBSD__)
+#include <errno.h>
+#endif
+
 #if !defined(MAX_PATH)
 #define MAX_PATH        260
 #endif

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -42,6 +42,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if defined(__OpenBSD__)
+#include <stdarg.h>
+#endif
+
 #include "doomtype.h"
 
 dboolean M_WriteFile(char *name, void *source, int length);

--- a/src/w_file.h
+++ b/src/w_file.h
@@ -39,6 +39,10 @@
 #if !defined(__W_FILE_H__)
 #define __W_FILE_H__
 
+#if defined(__OpenBSD__)
+#include <stdio.h>
+#endif
+
 typedef struct _wad_file_s wad_file_t;
 
 typedef struct


### PR DESCRIPTION
the ```m_misc.h``` fix adding ```<stdarg.h>``` resolves a very long-standing problem I've always had with compilation regarding ```va_list```.  i used to just quickly hack-fix it by prefixing ```__``` to ```va_list``` in ```m_misc.h```, until i found what seems to be a better way.  i believe stdarg.h is rather standard, might not hurt to always have it enabled but i guarded it to be safe.

same goes for the ```m_misc.c``` and ```w_file.h``` fixes.  these may be wanted on all platforms, if so we can simply remove the ```#if defined(__OpenBSD__)``` parts or at least restrict to 'if not windows...' for example..

Only the ```Makefile``` fix I'm pretty sure we want this on all platforms that use ```Makefile``` :)

Each commit message contains the error message resolved.