### PR TITLE
Switches a contributor's credit from GitHub/Twitter handle to real name.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,7 +75,7 @@ Claude Freeman ("ConSiGno"/"sneakernets")
 Dani Ventas
 Darren Mason
 Драган Поняшкин-Спаркс
-"duganchen"
+Dugan Chen
 Fabian Greffrath
 "HenitoKisou"
 "Hoodie"


### PR DESCRIPTION
That's me. I'd prefer to be credited using my real name please.