### PR TITLE
Prtsc key works in Linux

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2803,8 +2803,15 @@ dboolean M_Responder(event_t *ev)
     }
 
     // screenshot
-    if (key == key_screenshot && key != KEY_PRINTSCREEN)
+    if (key == key_screenshot) {
+#if defined(__linux__)
         G_ScreenShot();
+#else
+        if (key != KEY_PRINTSCREEN) {
+            G_ScreenShot();
+        }
+#endif
+    }
 
     // Pop-up menu?
     if (!menuactive)


### PR DESCRIPTION
I'm not sure if this is the best way to do it, but this gets the PrtScn key working in Linux.

Before this commit, the PrtScn key has not effect in Linux. Not even after "bind printscreen +screenshot".

After this commit, "bind printscreen +screenshot" makes the PrtScn key takes screenshots when Doom Retro is running in Linux.