### PR TITLE
Accounts for wordexp not being available on OpenBSD

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -794,7 +794,7 @@ dboolean D_CheckParms(void)
 {
     dboolean    result = false;
 
-#if !defined(WIN32) && !defined()
+#if !defined(WIN32) && !defined(__OpenBSD__)
     wordexp_t p;
 #endif
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -794,7 +794,7 @@ dboolean D_CheckParms(void)
 {
     dboolean    result = false;
 
-#if !defined(WIN32)
+#if !defined(WIN32) && !defined()
     wordexp_t p;
 #endif
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -81,7 +81,9 @@
 #include <dirent.h>
 #include <fnmatch.h>
 #include <libgen.h>
+#if !defined(__OpenBSD__)
 #include <wordexp.h>
+#endif
 #endif
 
 //
@@ -855,7 +857,7 @@ dboolean D_CheckParms(void)
             else
             {
                 // otherwise try the iwadfolder setting in doomretro.cfg
-#if defined(WIN32)
+#if defined(WIN32) || defined(__OpenBSD__)
                 M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", iwadfolder,
                     (iwadrequired == doom ? "DOOM.WAD" : "DOOM2.WAD"));
 #else
@@ -887,7 +889,7 @@ dboolean D_CheckParms(void)
                 else
                 {
                     // still nothing? try the DOOMWADDIR environment variable
-#if defined(WIN32)
+#if defined(WIN32) || defined(__OpenBSD__)
                     M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s",
                         getenv("DOOMWADDIR"), (iwadrequired == doom ? "DOOM.WAD" :
                             "DOOM2.WAD"));


### PR DESCRIPTION
Accounts for wordexp not being available on OpenBSD. As per this thread:

https://github.com/bradharding/doomretro/commit/f85031c0887fd11b20df26f9ad2bd1f696f09dfc#commitcomment-18717630