### PR TITLE
dehpattern substitution fixed

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -608,7 +608,7 @@ static char *FindDehPath(char *path, char *ext, char *pattern)
 
     M_StringCopy(pathcopy, path, pathlen + 1);
     dehpattern = M_StringReplace(basename(pathcopy), ".wad", pattern);
-    dehpattern = M_StringReplace(basename(pathcopy), ".WAD", pattern);
+    dehpattern = M_StringReplace(dehpattern, ".WAD", pattern);
     M_StringCopy(pathcopy, path, pathlen);
     dehdir = dirname(pathcopy);
     dirp = opendir(dehdir);


### PR DESCRIPTION
This fixes the substitution used to case-insensitively find deh and beh files for a wad.

The issue was pointed out here:

https://github.com/bradharding/doomretro/commit/24560539649d08f70ddba55c1ddebe0c48e3d07a#commitcomment-18804765