### PR TITLE
fix compilation on OpenBSD

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -63,7 +63,10 @@
 #endif
 
 #if defined(__OpenBSD__)
+#include <dirent.h>
 #include <errno.h>
+#include <libgen.h>
+#include <unistd.h>
 #endif
 
 #if defined(__linux__)


### PR DESCRIPTION
fix:
```
cc -O2 -g `sdl2-config --cflags` -DX11 -c m_misc.c -o m_misc.o
m_misc.c: In function 'M_GetAppDataFolder':
m_misc.c:184: error: 'DIR' undeclared (first use in this function)
m_misc.c:184: error: (Each undeclared identifier is reported only once
m_misc.c:184: error: for each function it appears in.)
m_misc.c:184: error: 'resourceDir' undeclared (first use in this function)
m_misc.c: In function 'M_GetResourceFolder':
m_misc.c:223: error: 'DIR' undeclared (first use in this function)
m_misc.c:223: error: 'resourceDir' undeclared (first use in this function)
gmake: *** [Makefile:58: m_misc.o] Error 1
```