### PR TITLE
Various level-specific fixes for Plutonia (part 1)

### DIFF
--- a/src/p_fix.c
+++ b/src/p_fix.c
@@ -649,6 +649,8 @@ linefix_t linefix[] =
     { doom,             4,   7,     475,    0, "",         "",            "",            DEFAULT,       142, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom,             4,   7,     477,    0, "",         "",            "",            DEFAULT,         8, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom,             4,   7,     478,    0, "",         "",            "",            DEFAULT,         8, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { doom,             4,   7,     989,    0, "",         "",            "",            DEFAULT,        94, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { doom,             4,   7,     991,    0, "",         "",            "",            DEFAULT,        94, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
     { doom,             4,   8,      69,    0, "",         "",            "",                 24,       -64, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom,             4,   8,      94,    0, "",         "",            "",                  4,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1071,10 +1073,13 @@ linefix_t linefix[] =
 
    // mission,    episode, map, linedef, side, toptexture, middletexture, bottomtexture,  offset, rowoffset, flags,                     special,                                        tag
 
+    { pack_plut,        1,   1,    1110,    0, "",         "",            "",                  0,         0, DEFAULT,                   DEFAULT,                                    DEFAULT },
+   
     { pack_plut,        1,   4,     303,    1, "",         "MIDBRONZ",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,   4,     308,    1, "",         "MIDBRONZ",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,   4,     762,    1, "",         "MIDBARS3",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,   4,     763,    1, "",         "MIDBARS3",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,   4,     975,    0, "",         "",            "",                 87,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
     { pack_plut,        1,   6,    1337,    1, "",         "MIDGRATE",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,   6,    1343,    1, "",         "MIDGRATE",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },


### PR DESCRIPTION
### Levels inspected: 1 to 11.

More to come, of course, but I see that Plutonia is well polished already.

- **Map 01**
Linedef 1110: fixed offsets of the red key wall texture.
http://i.imgur.com/iGV5VC7.png

- **Map 04**
Linedef 975: fixed offset of the exit-like doorway.
http://i.imgur.com/ODLL6k2.png

#### Back to the Ultimate Doom

- **E4M7**
Linedefs 989 and 991: I have forgot them to previous commit, sorry. It makes vertical alignment more proper, but it's hard to show them both in one screenshots, it's opposite walls.
http://i.imgur.com/ZCB5L4S.png
