### PR TITLE
Various level-specific fixes for Plutonia (part 2)

### DIFF
--- a/src/p_fix.c
+++ b/src/p_fix.c
@@ -1127,6 +1127,8 @@ linefix_t linefix[] =
     { pack_plut,        1,  20,     333,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  20,     511,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  20,     517,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  20,     876,    0, "",         "",            "",            DEFAULT,        72, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  20,     882,    0, "",         "",            "",            DEFAULT,        72, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  20,     904,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  20,    1110,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  20,    1115,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1202,6 +1204,7 @@ linefix_t linefix[] =
     { pack_plut,        1,  30,     730,    0, "ROCKRED1", "",            "ROCKRED1",    DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
     { pack_plut,        1,  31,     682,    1, "",         "MIDBARS1",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  31,     929,    0, "",         "",            "",            DEFAULT,        54, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
     { pack_plut,        1,  32,     569,    0, "A-MOSROK", "",            "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  32,     570,    0, "A-MOSROK", "",            "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1446,6 +1449,9 @@ sectorfix_t sectorfix[] =
     { pack_plut,        1,   4,    103, "RROCK03", "",             DEFAULT,       DEFAULT, DEFAULT, DEFAULT },
 
     { pack_plut,        1,   8,    130, "",        "",             DEFAULT,             0, DEFAULT, DEFAULT },
+
+    { pack_plut,        1,  16,     97, "",        "NUKAGE1",      DEFAULT,       DEFAULT, DEFAULT, DEFAULT },
+    { pack_plut,        1,  16,    104, "",        "NUKAGE1",      DEFAULT,       DEFAULT, DEFAULT, DEFAULT },
 
     { pack_plut,        1,  26,    156, "",        "",             DEFAULT,       DEFAULT,       0, DEFAULT },
 


### PR DESCRIPTION
### Levels inspected: 12 to 20 (also 31 and 32).
There is few important moments, please pay attention.

- **MAP12**
Linedef 230: this linedef have missing "impassible" flag. I have not touched it, because it's beloved by speed runners. Just FYI, maybe it will be better to leave this "as is".

- **MAP16**
Sectors 97 and 104: fixed incorrect ceiling textures. Player will see them without free look, so maybe it will be good for future, in case of one day Doom Retro will have free mouse look.
http://i.imgur.com/daw4N2G.png <br />
**Attention needed:** There is a known problem in exit room. If player will fall down from these sectors (http://i.imgur.com/3PfAU6X.png) to the slime, there will be no way back, since slime is not damaging and there is no teleport back. Only `idclip` will help.<br />
I see two ways to fix it:
<br />1. Add super damage effect 16 to slime sectors, so if player will fall down, he will die (quickly, no need to wait long). I was trying to implement this in `sectorfix` by adding special 16 to sectors 95 and 96 - no luck. For some reason it is not working. Maybe setting sector effects other than 0  is not supported by the code?
<br />2. Make sector's outlines (colored red in screenshot about) impassible. This will prevent player's falling into slime, but does not looks logical enough, since there is no visible barriers in outlines.

- **MAP20**
Linedefs 876 and 882: corrected vertical offsets.
http://i.imgur.com/VoeWhO6.png

- **MAP31**
Linedef 929: corrected vertical offset.
http://i.imgur.com/OYMuRNF.png