### PR TITLE
Various level-specific fixes for Plutonia (part 3)

### DIFF
--- a/src/p_fix.c
+++ b/src/p_fix.c
@@ -828,7 +828,9 @@ linefix_t linefix[] =
     { doom2,            1,  18,       5,    0, "",         "SUPPORT3",    "",                  4,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,      17,    0, "",         "",            "",            DEFAULT,        64, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,      18,    0, "",         "",            "",            DEFAULT,        64, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { doom2,            1,  18,      91,    0, "",         "",            "",                -32,       -80, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,     385,    0, "",         "",            "",            DEFAULT,       -16, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { doom2,            1,  18,     386,    0, "",         "",            "",            DEFAULT,       -80, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,     451,    0, "",         "DOORSTOP",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,     459,    0, "",         "DOORSTOP",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { doom2,            1,  18,     483,    0, "",         "",            "",                  8,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1137,6 +1139,8 @@ linefix_t linefix[] =
     { pack_plut,        1,  22,      61,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  22,     375,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  22,     393,    1, "",         "MIDBARS3",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  22,    1026,    0, "",         "",            "",                 45,       -88, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  22,    1028,    0, "",         "",            "",                 64,       -88, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  22,    1033,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  22,    1034,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  22,    1035,    1, "",         "A-RAIL1",     "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1192,6 +1196,10 @@ linefix_t linefix[] =
     { pack_plut,        1,  28,     676,    0, "",         "",            "BRICK10",     DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,     834,    0, "",         "",            "WOOD8",       DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,     835,    0, "",         "",            "WOOD8",       DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  28,    1232,    0, "",         "",            "",            DEFAULT,        -1, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  28,    1233,    0, "",         "",            "",            DEFAULT,        -1, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  28,    1234,    0, "",         "",            "",            DEFAULT,        -1, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  28,    1235,    0, "",         "",            "",            DEFAULT,        -1, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,    2073,    0, "",         "MIDGRATE",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,    2352,    1, "",         "MIDGRATE",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,    2360,    1, "",         "MIDGRATE",    "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
@@ -1199,7 +1207,12 @@ linefix_t linefix[] =
     { pack_plut,        1,  28,    2496,    0, "BRICK10",  "",            "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  28,    2496,    1, "",         "",            "METAL2",      DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
+    { pack_plut,        1,  29,    1144,    0, "",         "",            "",                -37,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  29,    1147,    0, "",         "",            "",                 19,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  29,    1150,    0, "",         "",            "",                 10,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
     { pack_plut,        1,  29,    2842,    0, "PANCASE2", "",            "",            DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  29,    2936,    0, "",         "",            "",                 22,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
+    { pack_plut,        1,  29,    2938,    0, "",         "",            "",                 26,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
     { pack_plut,        1,  30,     730,    0, "ROCKRED1", "",            "ROCKRED1",    DEFAULT,   DEFAULT, DEFAULT,                   DEFAULT,                                    DEFAULT },
 
@@ -1454,6 +1467,9 @@ sectorfix_t sectorfix[] =
     { pack_plut,        1,  16,     96, "",        "",             DEFAULT,       DEFAULT, DamageNegative10Or20PercentHealth, DEFAULT },
     { pack_plut,        1,  16,     97, "",        "NUKAGE1",      DEFAULT,       DEFAULT, DEFAULT,                           DEFAULT },
     { pack_plut,        1,  16,    104, "",        "NUKAGE1",      DEFAULT,       DEFAULT, DEFAULT,                           DEFAULT },
+
+    { pack_plut,        1,  29,    178, "",        "",                 201,       DEFAULT, DEFAULT,                           DEFAULT },
+    { pack_plut,        1,  29,    224, "",        "",                 156,       DEFAULT, DEFAULT,                           DEFAULT },
 
     { pack_plut,        1,  26,    156, "",        "",             DEFAULT,       DEFAULT, Normal,                            DEFAULT },
 


### PR DESCRIPTION
Here we go, final part 3.

- **MAP22**

Linedefs 1026 and 1028: Some nicer offets for the bottom of nukage walls
Nothing I can do on the opposite side, though - changing vertical offsets simply makes metal grate texture goes away.
http://i.imgur.com/BAJu9ND.png

- **MAP28**

Linedefs 1232, 1233, 1234, 1233: four lamp textures lowered down to 1px.
http://i.imgur.com/xb5jNS6.png

- **MAP29**

Sector 178: floor height increased just few map units high to make a skull textures looking proper. Texture offset correction is not working here due to wall height.
http://i.imgur.com/qCHttLJ.png

Sector 224: same as above.
http://i.imgur.com/WQPaep9.png

Linedefs 1144, 1147, 1150: nicer and centered offsets, please, it's a living-like building!
http://i.imgur.com/ddg0UvD.png

Linedefs 2936 and 2938: little metal "spikes" hidden completely.
http://i.imgur.com/SSE26mL.png

### Back to the Hell on Earth

- **MAP18**

Linedefs 91 and 386: fixed vertical offsets on that walls. There is some more vertical misalignments, but fixing them will require to modify all the blocks, this is deffinitly bad idea.
http://i.imgur.com/EGeFMAO.png and http://i.imgur.com/K474Gw0.png

_This map becomes my virtual home for two last months. All the things was borned and tested there - golden eyes, high res, fix of chansaw sound and many many others! :)_

### And most important

I've additionally checked all Doom 1, 2 and Plutonia maps by using console `map` command and can confirm that there is no any warnings.

Next stop - TNT Evilution!