### PR TITLE
small memory leaks fixes:

### DIFF
--- a/src/c_cmds.c
+++ b/src/c_cmds.c
@@ -3928,6 +3928,8 @@ static void vanilla_cmd_func2(char *cmd, char *parms)
 
             if (SC_GetString())
                 C_ValidateInput(M_StringJoin(cvar, " ", sc_String, NULL));
+
+            free(cvar);
         }
 
         HU_PlayerMessage(s_STSTR_VMON, false);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1595,7 +1595,7 @@ static void D_DoomMainSetup(void)
     int         choseniwad = 0;
     static char lumpname[6];
     char        *appdatafolder = M_GetAppDataFolder();
-    char        *iwadfile = malloc(MAX_PATH);
+    char        *iwadfile = NULL;
     int         startloadgame;
 
     packagewad = M_StringJoin(M_GetResourceFolder(), DIR_SEPARATOR_S, PACKAGE_WAD, NULL);


### PR DESCRIPTION
D_FindIWAD makes the previous malloc call lose the address.