### PR TITLE
CI builds using clang and gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,23 +40,19 @@ language: c
 
 compiler:
     - clang
+    - gcc
 
 sudo: required
 
 dist: trusty
 
-before_install:
-    - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz
-    - tar xf cmake-3.4.3-Linux-x86_64.tar.gz
-    - export PATH=$PWD/cmake-3.4.3-Linux-x86_64/bin:$PATH
-
 addons:
     apt:
         packages:
+            - cmake3
             - libsdl2-dev
             - libsdl2-mixer-dev
             - libsdl2-image-dev
 
 script:
     - mkdir build && cd build && cmake .. && make
-    - cd ../src && make


### PR DESCRIPTION
Improvements to continuous integration:

- cmake 3 is now installed from the official repositories (this results in much faster builds!)
- it's now built using both clang and gcc

Please note that because we're now also building with GCC, this now  tests only the CMake build. As src/Makefile doesn't (currently) work with Ubuntu Trusty's GCC, I've removed it from the CI build steps (for now).

References:

- https://github.com/bradharding/doomretro/issues/341
- https://github.com/bradharding/doomretro/issues/300