### PR TITLE
Fix for deprecated function

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -983,7 +983,7 @@ static int D_OpenWADLauncher(void)
 
     NSInteger   clicked = [panel runModal];
 
-    fileopenedok = (clicked == NSFileHandlingPanelOKButton);
+    fileopenedok = (clicked == NSModalResponseOK);
 #endif
 
     if (fileopenedok)


### PR DESCRIPTION
"'NSFileHandlingPanelOKButton' is deprectaed: first deprecated in macOS 10.13
Replace 'NSFileHandlingPanelOKButton' with 'NSModalResponseOK'"