### PR TITLE
Fix for non doom and doom2 pwads

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1348,7 +1348,7 @@ static int D_OpenWADLauncher(void)
                     char    *pwadpass1 = (char *)[[url lastPathComponent] UTF8String];
 #endif
 
-                    if (W_WadType(fullpath) == PWAD && !D_IsUnsupportedPWAD(fullpath)
+                    if (!iwadfound && W_WadType(fullpath) == PWAD && !D_IsUnsupportedPWAD(fullpath)
                         && !D_IsDehFile(fullpath))
                     {
                         int iwadrequired = IWADRequiredByPWAD(fullpath);


### PR DESCRIPTION
Code was not checking to see if an iwad had already been found and was therefore adding doom2.wad even when plutonia.wad or tnt.wad were already found. See Issue https://github.com/bradharding/doomretro/issues/418