### PR TITLE
reverting my proposition for the issue #418

### DIFF
--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -40,7 +40,7 @@
 #define __R_PLANE_H__
 
 // killough 10/98: special mask indicates sky flat comes from sidedef
-#define PL_SKYFLAT  0x10000
+#define PL_SKYFLAT  0x400000000
 
 // Visplane related.
 extern int      *lastopening;


### PR DESCRIPTION
@bradharding was correct in this issue assuming PL_SKYFLAT might not need to be lowered down.
However the original appears to be too low for some.
Indeed, after having spent more time trying out few pwad it appears most of the time images data were read beyond their real size so on Mac sometimes it worked but should not but having enabled proper memory boundaries checkers ... it crashed as mainly PL_SLYFLAT mask appeared to be to low.

Please @bradharidng and possibly @jasoncarlough tries out few pwad on your own side to see if it really fixes.

Sorry for inconveniences.