### PR TITLE
Fixed conditions

### DIFF
--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -277,14 +277,13 @@ dboolean P_UseSpecialLine(mobj_t *thing, line_t *line, int side)
             switch ((line->special & TriggerType) >> TriggerTypeShift)
             {
                 case PushOnce:
-                    if (!side && linefunc(line))
+                    if (linefunc(line))
                         line->special = 0;
 
                     return true;
 
                 case PushMany:
-                    if (!side)
-                        linefunc(line);
+                    linefunc(line);
 
                     return true;
 

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -273,21 +273,18 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec, int *floorlightlevel, int
             tempsec->floor_xoffs = s->floor_xoffs;
             tempsec->floor_yoffs = s->floor_yoffs;
 
-            if (underwater)
+            if (s->ceilingpic == skyflatnum)
             {
-                if (s->ceilingpic == skyflatnum)
-                {
-                    tempsec->interpfloorheight = tempsec->interpceilingheight + 1;
-                    tempsec->ceilingpic = tempsec->floorpic;
-                    tempsec->ceiling_xoffs = tempsec->floor_xoffs;
-                    tempsec->ceiling_yoffs = tempsec->floor_yoffs;
-                }
-                else
-                {
-                    tempsec->ceilingpic = s->ceilingpic;
-                    tempsec->ceiling_xoffs = s->ceiling_xoffs;
-                    tempsec->ceiling_yoffs = s->ceiling_yoffs;
-                }
+                tempsec->interpfloorheight = tempsec->interpceilingheight + 1;
+                tempsec->ceilingpic = tempsec->floorpic;
+                tempsec->ceiling_xoffs = tempsec->floor_xoffs;
+                tempsec->ceiling_yoffs = tempsec->floor_yoffs;
+            }
+            else
+            {
+                tempsec->ceilingpic = s->ceilingpic;
+                tempsec->ceiling_xoffs = s->ceiling_xoffs;
+                tempsec->ceiling_yoffs = s->ceiling_yoffs;
             }
 
             tempsec->lightlevel = s->lightlevel;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
doomretro/src/r_bsp.c       276     warn    V547 Expression 'underwater' is always true.
doomretro/src/p_switch.c    280     warn    V560 A part of conditional expression is always true: !side.
doomretro/src/p_switch.c    286     warn    V547 Expression '!side' is always true.