### PR TITLE
New static analyser issues 

### DIFF
--- a/src/r_data.c
+++ b/src/r_data.c
@@ -703,7 +703,9 @@ static inline void precache_lump(int l)
 void R_PrecacheLevel(void)
 {
     byte    *hitlist = malloc(MAX(numtextures, MAX(numflats, NUMSPRITES)));
-
+    if (!hitlist)
+        return;
+  
     // Precache flats.
     memset(hitlist, 0, numflats);
 

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -372,7 +372,7 @@ static void WI_drawWILV(int y, char *str)
     {
         int j = chartoi[(int)str[i]];
 
-        if (str[i] == '\'' && (!i || (i > 0 && str[i - 1] == ' ')))
+        if (str[i] == '\'' && (str[i - 1] == ' '))
             j = 41;
 
         if (j == -1)


### PR DESCRIPTION
I like your project and I'm exploring it as part of the competition the Pinguem.ru competition on finding errors in open source projects. New warnings, found using PVS-Studio:
doomretro/src/r_data.c      708     warn    V575 The potential null pointer is passed into 'memset' function. Inspect the first argument.
doomretro/src/wi_stuff.c    375     warn    V728 An excessive check 'i > 0' can be simplified. The '||' operator is surrounded by opposite expressions.