### PR TITLE
Many memory leak fixes

### DIFF
--- a/src/c_console.c
+++ b/src/c_console.c
@@ -1845,8 +1845,12 @@ void C_PrintSDLVersions(void)
     const int   revision = SDL_GetRevisionNumber();
 
     if (revision)
+    {
+        char *revision_str = commify(revision);
         C_Output("Using version %i.%i.%i (revision %s) of <b>%s</b>.", SDL_MAJOR_VERSION, SDL_MINOR_VERSION,
-            SDL_PATCHLEVEL, commify(revision), SDL_FILENAME);
+            SDL_PATCHLEVEL, revision_str, SDL_FILENAME);
+        free(revision_str);
+    }
     else
         C_Output("Using version %i.%i.%i of <b>%s</b>.", SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL,
             SDL_FILENAME);

--- a/src/c_console.c
+++ b/src/c_console.c
@@ -206,10 +206,12 @@ void C_PctCVAROutput(char *cvar, int value)
 
 void C_StrCVAROutput(char *cvar, char *string)
 {
-    if (consolestrings && M_StringStartsWith(console[consolestrings - 1].string, M_StringJoin(cvar, " ", NULL)))
+    char *cvar_free = M_StringJoin(cvar, " ", NULL);
+    if (consolestrings && M_StringStartsWith(console[consolestrings - 1].string, cvar_free))
         consolestrings--;
 
     C_Input("%s %s", cvar, string);
+    free(cvar_free);
 }
 
 void C_CCMDOutput(const char *ccmd)

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2124,11 +2124,19 @@ void ProcessDehFile(char *filename, int lumpnum)
         dehcount++;
 
     if (infile.lump)
-        C_Output("Parsed %s line%s in the <b>%s</b> lump in %s <b>%s</b>.", commify(linecount), (linecount > 1 ? "s" : ""),
+    {
+        char *linecount_str = commify(linecount);
+        C_Output("Parsed %s line%s in the <b>%s</b> lump in %s <b>%s</b>.", linecount_str, (linecount > 1 ? "s" : ""),
             uppercase(lumpinfo[lumpnum]->name), (W_WadType(filename) == IWAD ? "IWAD" : "PWAD"), filename);
+        free(linecount_str);
+    }
     else
-        C_Output("Parsed %s line%s in the <i><b>DeHackEd</b></i>%s file <b>%s</b>.", commify(linecount), (linecount > 1 ? "s" : ""),
+    {
+        char *linecount_str = commify(linecount);
+        C_Output("Parsed %s line%s in the <i><b>DeHackEd</b></i>%s file <b>%s</b>.", linecount_str, (linecount > 1 ? "s" : ""),
             (M_StringEndsWith(uppercase(filename), "BEX") ? " with <i><b>BOOM</b></i> extensions" : ""), GetCorrectCase(filename));
+        free(linecount_str);
+    }
 }
 
 // ====================================================================

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2126,16 +2126,20 @@ void ProcessDehFile(char *filename, int lumpnum)
     if (infile.lump)
     {
         char *linecount_str = commify(linecount);
+        char *lumpname = uppercase(lumpinfo[lumpnum]->name);
         C_Output("Parsed %s line%s in the <b>%s</b> lump in %s <b>%s</b>.", linecount_str, (linecount > 1 ? "s" : ""),
-            uppercase(lumpinfo[lumpnum]->name), (W_WadType(filename) == IWAD ? "IWAD" : "PWAD"), filename);
+            lumpname, (W_WadType(filename) == IWAD ? "IWAD" : "PWAD"), filename);
         free(linecount_str);
+        free(lumpname);
     }
     else
     {
         char *linecount_str = commify(linecount);
+        char *filename_free = uppercase(filename);
         C_Output("Parsed %s line%s in the <i><b>DeHackEd</b></i>%s file <b>%s</b>.", linecount_str, (linecount > 1 ? "s" : ""),
-            (M_StringEndsWith(uppercase(filename), "BEX") ? " with <i><b>BOOM</b></i> extensions" : ""), GetCorrectCase(filename));
+            (M_StringEndsWith(filename_free, "BEX") ? " with <i><b>BOOM</b></i> extensions" : ""), GetCorrectCase(filename));
         free(linecount_str);
+        free(filename_free);
     }
 }
 

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -327,8 +327,10 @@ void D_IdentifyIWADByName(char *name)
         if (M_StringCompare(name, iwad))
         {
             gamemission = iwads[i].mission;
+            free(iwad);
             break;
         }
+        free(iwad);
     }
 
     if (M_StringCompare(name, "HACX.WAD"))

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -542,7 +542,10 @@ void D_SetSaveGameFolder(dboolean output)
         M_MakeDirectory(appdatafolder);
         savegamefolder = M_StringJoin(appdatafolder, DIR_SEPARATOR_S, "savegames", DIR_SEPARATOR_S, NULL);
         M_MakeDirectory(savegamefolder);
+        char *savegamefolder_free = savegamefolder;
         savegamefolder = M_StringJoin(savegamefolder, (*pwadfile ? pwadfile : iwad_name), DIR_SEPARATOR_S, NULL);
+        free(appdatafolder);
+        free(savegamefolder_free);
     }
 
     M_MakeDirectory(savegamefolder);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1623,13 +1623,13 @@ static void D_DoomMainSetup(void)
     char        *appdatafolder = M_GetAppDataFolder();
     char        *iwadfile;
     int         startloadgame;
-
-    packagewad = M_StringJoin(M_GetResourceFolder(), DIR_SEPARATOR_S, PACKAGE_WAD, NULL);
-
+    char        *resourcefolder = M_GetResourceFolder();
+    packagewad = M_StringJoin(resourcefolder, DIR_SEPARATOR_S, PACKAGE_WAD, NULL);
+    free(resourcefolder);
     M_MakeDirectory(appdatafolder);
 
     packageconfig = M_StringJoin(appdatafolder, DIR_SEPARATOR_S, PACKAGE_CONFIG, NULL);
-
+    free(appdatafolder);
     C_Output("");
     C_PrintCompileDate();
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1718,7 +1718,11 @@ static void D_DoomMainSetup(void)
     else if (stat_runs == 1)
         C_Output("<i><b>"PACKAGE_NAME"</b></i> has now been run twice.");
     else
-        C_Output("<i><b>"PACKAGE_NAME"</b></i> has now been run %s times.", commify(SafeAdd(stat_runs, 1)));
+    {
+        char *stat_runs_str = commify(SafeAdd(stat_runs, 1));
+        C_Output("<i><b>"PACKAGE_NAME"</b></i> has now been run %s times.", stat_runs_str);
+        free(stat_runs_str);
+    }
 
     if (!M_FileExists(packagewad))
         I_Error("%s can't be found.", packagewad);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2043,8 +2043,9 @@ static void D_DoomMainSetup(void)
         else
             D_StartTitle(M_CheckParm("-nosplash") || SCREENSCALE == 1);   // start up intro loop
     }
-
-    C_Output("Startup took %s seconds to complete.", striptrailingzero((I_GetTimeMS() - startuptimer) / 1000.0f, 1));
+    char *time = striptrailingzero((I_GetTimeMS() - startuptimer) / 1000.0f, 1);
+    C_Output("Startup took %s seconds to complete.", time);
+    free(time);
 
     // Ty 04/08/98 - Add 5 lines of misc. data, only if non-blank
     // The expectation is that these will be set in a .bex file

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1367,8 +1367,14 @@ static void SetVideoMode(dboolean output)
                 SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayindex), width, height, (windowflags | SDL_WINDOW_FULLSCREEN));
 
             if (output)
+            {
+                char *width_str = commify(width);
+                char *height_str = commify(height);
                 C_Output("Staying at the native desktop resolution of %s\xD7%s with a %s aspect ratio.",
-                    commify(width), commify(height), ratio);
+                    width_str, height_str, ratio);
+                free(width_str);
+                free(height_str);
+            }
         }
         else
         {
@@ -1380,7 +1386,13 @@ static void SetVideoMode(dboolean output)
                 SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayindex), width, height, (windowflags | SDL_WINDOW_FULLSCREEN));
 
             if (output)
-                C_Output("Switched to a resolution of %s\xD7%s with a %s aspect ratio.", commify(width), commify(height), ratio);
+            {
+                char *width_str = commify(width);
+                char *height_str = commify(height);
+                C_Output("Switched to a resolution of %s\xD7%s with a %s aspect ratio.", width_str, height_str, ratio);
+                free(width_str);
+                free(height_str);
+            }
         }
     }
     else
@@ -1401,16 +1413,28 @@ static void SetVideoMode(dboolean output)
                 SDL_WINDOWPOS_CENTERED_DISPLAY(displayindex), width, height, windowflags);
 
             if (output)
+            {
+                char *width_str = commify(width);
+                char *height_str = commify(height);
                 C_Output("Created a resizable window with dimensions %s\xD7%s centered on the screen.",
-                    commify(width), commify(height));
+                    width_str, height_str);
+                free(width_str);
+                free(height_str);
+            }
         }
         else
         {
             window = SDL_CreateWindow(PACKAGE_NAME, windowx, windowy, width, height, windowflags);
 
             if (output)
+            {
+                char *width_str = commify(width);
+                char *height_str = commify(height);
                 C_Output("Created a resizable window with dimensions %s\xD7%s at (%i,%i).",
-                    commify(width), commify(height), windowx, windowy);
+                    width_str, height_str, windowx, windowy);
+                free(width_str);
+                free(height_str);
+            }
         }
     }
 
@@ -1514,16 +1538,36 @@ static void SetVideoMode(dboolean output)
         {
             if (nearestlinear)
             {
+                char *upscaledwidth_str = commify(upscaledwidth * SCREENWIDTH);
+                char *upscaledheight_str = commify(upscaledheight * SCREENHEIGHT);
+                char *width_str = commify(height * 4 / 3);
+                char *height_str = commify(height);
                 C_Output("The %i\xD7%i screen is scaled up to %s\xD7%s using nearest-neighbor interpolation.",
-                    SCREENWIDTH, SCREENHEIGHT, commify(upscaledwidth * SCREENWIDTH), commify(upscaledheight * SCREENHEIGHT));
-                C_Output("It is then scaled down to %s\xD7%s using linear filtering.", commify(height * 4 / 3), commify(height));
+                    SCREENWIDTH, SCREENHEIGHT, upscaledwidth_str, upscaledheight_str);
+                C_Output("It is then scaled down to %s\xD7%s using linear filtering.", width_str, height_str);
+                free(upscaledwidth_str);
+                free(upscaledheight_str);
+                free(width_str);
+                free(height_str);
             }
             else if (M_StringCompare(vid_scalefilter, vid_scalefilter_linear) && !software)
+            {
+                char *width_str = commify(height * 4 / 3);
+                char *height_str = commify(height);
                 C_Output("The %i\xD7%i screen is scaled up to %s\xD7%s using linear filtering.",
-                    SCREENWIDTH, SCREENHEIGHT, commify(height * 4 / 3), commify(height));
+                    SCREENWIDTH, SCREENHEIGHT, width_str, height_str);
+                free(width_str);
+                free(height_str);
+            }
             else
+            {
+                char *width_str = commify(height * 4 / 3);
+                char *height_str = commify(height);
                 C_Output("The %i\xD7%i screen is scaled up to %s\xD7%s using nearest-neighbor interpolation.",
-                    SCREENWIDTH, SCREENHEIGHT, commify(height * 4 / 3), commify(height));
+                    SCREENWIDTH, SCREENHEIGHT, width_str, height_str);
+                free(width_str);
+                free(height_str);
+            }
         }
 
         I_CapFPS(0);
@@ -1548,7 +1592,11 @@ static void SetVideoMode(dboolean output)
                     I_CapFPS(vid_capfps);
 
                     if (output)
-                        C_Output("The framerate is capped at %s FPS.", commify(vid_capfps));
+                    {
+                        char *vid_capfps_str = commify(vid_capfps);
+                        C_Output("The framerate is capped at %s FPS.", vid_capfps_str);
+                        free(vid_capfps_str);
+                    }
                 }
             }
         }
@@ -1568,7 +1616,11 @@ static void SetVideoMode(dboolean output)
                 }
 
                 if (vid_capfps)
-                    C_Output("The framerate is capped at %s FPS.", commify(vid_capfps));
+                {
+                    char *vid_capfps_str = commify(vid_capfps);
+                    C_Output("The framerate is capped at %s FPS.", vid_capfps);
+                    free(vid_capfps_str);
+                }
                 else
                     C_Output("The framerate is uncapped.");
             }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1178,16 +1178,22 @@ void GetWindowSize(void)
     }
     else
     {
-        int w = atoi(uncommify(width));
-        int h = atoi(uncommify(height));
-
+        char *width_str = uncommify(width);
+        char *height_str = uncommify(height);
+        int w = atoi(width_str);
+        int h = atoi(height_str);
+        free(width_str);
+        free(height_str);
         if (w < ORIGINALWIDTH + windowborderwidth || h < ORIGINALWIDTH * 3 / 4 + windowborderheight)
         {
             char    size[16];
-
             windowwidth = ORIGINALWIDTH + windowborderwidth;
             windowheight = ORIGINALWIDTH * 3 / 4 + windowborderheight;
-            M_snprintf(size, sizeof(size), "%sx%s", commify(windowwidth), commify(windowheight));
+            char *windowwidth_str = commify(windowwidth);
+            char *windowheight_str = commify(windowheight);
+            M_snprintf(size, sizeof(size), "%sx%s", windowwidth_str, windowheight_str);
+            free(windowwidth_str);
+            free(windowheight_str);
             vid_windowsize = strdup(size);
             M_SaveCVARs();
         }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -956,7 +956,9 @@ void M_LoadCVARs(char *filename)
 
         if (togglingvanilla)
         {
-            C_ValidateInput(M_StringJoin(cvar, " ", uncommify(value), NULL));
+            char *value_free = uncommify(value);
+            C_ValidateInput(M_StringJoin(cvar, " ", value_free, NULL));
+            free(value_free);
             continue;
         }
 
@@ -983,38 +985,58 @@ void M_LoadCVARs(char *filename)
                     break;
 
                 case DEFAULT_INT:
-                    M_StringCopy(value, uncommify(value), sizeof(value));
+                {
+                    char *value_free = uncommify(value);
+                    M_StringCopy(value, value_free, sizeof(value));
                     *(int *)cvars[i].location = ParseIntParameter(value, cvars[i].valuealiastype);
+                    free(value_free);
+                }
                     break;
 
                 case DEFAULT_INT_UNSIGNED:
-                    M_StringCopy(value, uncommify(value), sizeof(value));
+                {
+                    char *value_free = uncommify(value);
+                    M_StringCopy(value, value_free, sizeof(value));
                     sscanf(value, "%10u", (unsigned int *)cvars[i].location);
+                    free(value_free);
+                }
                     break;
 
                 case DEFAULT_INT_PERCENT:
-                    M_StringCopy(value, uncommify(value), sizeof(value));
+                {
+                    char *value_free = uncommify(value);
+                    M_StringCopy(value, value_free, sizeof(value));
                     s = strdup(value);
 
                     if (s[0] != '\0' && s[strlen(s) - 1] == '%')
                         s[strlen(s) - 1] = '\0';
 
                     *(int *)cvars[i].location = ParseIntParameter(s, cvars[i].valuealiastype);
+                    free(value_free);
+                }
                     break;
 
                 case DEFAULT_FLOAT:
-                    M_StringCopy(value, uncommify(value), sizeof(value));
+                {
+                    char *value_free = uncommify(value);
+                    M_StringCopy(value, value_free, sizeof(value));
                     *(float *)cvars[i].location = ParseFloatParameter(value, cvars[i].valuealiastype);
+                    free(value_free);
+                }
                     break;
 
                 case DEFAULT_FLOAT_PERCENT:
-                    M_StringCopy(value, uncommify(value), sizeof(value));
+                {
+                    char *value_free = uncommify(value);
+                    M_StringCopy(value, value_free, sizeof(value));
                     s = strdup(value);
 
                     if (s[0] != '\0' && s[strlen(s) - 1] == '%')
                         s[strlen(s) - 1] = '\0';
 
                     *(float *)cvars[i].location = ParseFloatParameter(s, cvars[i].valuealiastype);
+                    free(value_free);
+                }
                     break;
 
                 case DEFAULT_OTHER:

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -337,13 +337,21 @@ void M_SaveCVARs(void)
                     }
 
                 if (!flag)
-                    fputs(commify(v), file);
+                {
+                    char *v_str = commify(v);
+                    fputs(v_str, file);
+                    free(v_str);
+                }
 
                 break;
             }
 
             case DEFAULT_INT_UNSIGNED:
-                fputs(commify(*(unsigned int *)cvars[i].location), file);
+            {
+                char *cvars_location_free = commify(*(unsigned int *)cvars[i].location);
+                fputs(cvars_location_free, file);
+                free(cvars_location_free);
+            }
                 break;
 
             case DEFAULT_INT_PERCENT:
@@ -360,7 +368,11 @@ void M_SaveCVARs(void)
                     }
 
                 if (!flag)
-                    fprintf(file, "%s%%", commify(v));
+                {
+                    char *v_str = commify(v);
+                    fprintf(file, "%s%%", v_str);
+                    free(v_str);
+                }
 
                 break;
             }
@@ -409,7 +421,11 @@ void M_SaveCVARs(void)
                     }
 
                 if (!flag)
-                    fprintf(file, "%s%%", striptrailingzero(v, 1));
+                {
+                    char *v_str = striptrailingzero(v, 1);
+                    fprintf(file, "%s%%", v_str);
+                    free(v_str);
+                }
 
                 break;
             }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1015,8 +1015,14 @@ void M_LoadCVARs(char *filename)
 
     if (!togglingvanilla)
     {
-        C_Output("Loaded %s CVARs and %s player stats from <b>%s</b>.", commify(cvarcount), commify(statcount), filename);
-        C_Output("Bound %s actions to the keyboard, mouse and gamepad.", commify(bindcount));
+        char *cvarcount_str = commify(cvarcount);
+        char *statcount_str = commify(statcount);
+        char *bindcount_str = commify(bindcount);
+        C_Output("Loaded %s CVARs and %s player stats from <b>%s</b>.", cvarcount_str, statcount_str, filename);
+        C_Output("Bound %s actions to the keyboard, mouse and gamepad.", bindcount_str);
+        free(cvarcount_str);
+        free(statcount_str);
+        free(bindcount_str);
         M_CheckCVARs();
         cvarsloaded = true;
     }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -172,7 +172,7 @@ char *M_GetAppDataFolder(void)
     char    *resourceFolder = M_StringJoin(executableFolder, DIR_SEPARATOR_S".."
                 DIR_SEPARATOR_S"share"DIR_SEPARATOR_S"doomretro", NULL);
     DIR     *resourceDir = opendir(resourceFolder);
-
+    free(resourceFolder);
     if (resourceDir)
     {
         closedir(resourceDir);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -192,7 +192,7 @@ char *M_GetAppDataFolder(void)
 
         if (!(buffer = SDL_getenv("HOME")))
             buffer = getpwuid(getuid())->pw_dir;
-
+        free(executableFolder);
         return M_StringJoin(buffer, DIR_SEPARATOR_S".config"DIR_SEPARATOR_S, PACKAGE, NULL);
 #endif
     }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -215,6 +215,7 @@ char *M_GetResourceFolder(void)
     if (resourceDir)
     {
         closedir(resourceDir);
+        free(executableFolder);
         return resourceFolder;
     }
 

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -449,23 +449,26 @@ static void R_InitSpriteLumps(void)
         if (M_StringCompare(sc_String, "FIXSPRITEOFFSETS"))
         {
             SC_MustGetString();
-
-            if (M_StringCompare(pwadfile, removeext(sc_String)))
+            char *sc_String_free = removeext(sc_String);
+            if (M_StringCompare(pwadfile, sc_String_free))
                 fixspriteoffsets = true;
+            free(sc_String_free);
         }
         else if (M_StringCompare(sc_String, "NOTRANSLUCENCY"))
         {
             SC_MustGetString();
-
-            if (M_StringCompare(pwadfile, removeext(sc_String)))
+            char *sc_String_free = removeext(sc_String);
+            if (M_StringCompare(pwadfile, sc_String_free))
                 notranslucency = true;
+            free(sc_String_free);
         }
         else if (M_StringCompare(sc_String, "TELEFRAGONMAP30"))
         {
             SC_MustGetString();
-
-            if (M_StringCompare(pwadfile, removeext(sc_String)))
+            char *sc_String_free = removeext(sc_String);
+            if (M_StringCompare(pwadfile, sc_String_free))
                 telefragonmap30 = true;
+            free(sc_String_free);
         }
     }
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1448,7 +1448,11 @@ void V_Init(void)
     if ((p = M_CheckParmWithArgs("-shotdir", 1, 1)))
         M_StringCopy(screenshotfolder, myargv[p + 1], sizeof(screenshotfolder));
     else
-        M_snprintf(screenshotfolder, sizeof(screenshotfolder), "%s"DIR_SEPARATOR_S"screenshots", M_GetAppDataFolder());
+    {
+        char *appdatafolder = M_GetAppDataFolder();
+        M_snprintf(screenshotfolder, sizeof(screenshotfolder), "%s"DIR_SEPARATOR_S"screenshots", appdatafolder);
+        free(appdatafolder);
+    }
 }
 
 char            lbmname1[MAX_PATH];

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -198,10 +198,10 @@ wadfile_t *W_AddFile(char *filename, dboolean automatic)
     }
 
     free(fileinfo);
-
-    C_Output("%s %s lump%s from %s <b>%s</b>.", (automatic ? "Automatically added" : "Added"), commify(numlumps - startlump),
+    char *lumps_str = commify(numlumps - startlump);
+    C_Output("%s %s lump%s from %s <b>%s</b>.", (automatic ? "Automatically added" : "Added"), lumps_str,
         (numlumps - startlump == 1 ? "" : "s"), (wadfile->type == IWAD ? "IWAD" : "PWAD"), wadfile->path);
-
+    free(lumps_str);
     if (!packagewadadded)
     {
         packagewadadded = true;


### PR DESCRIPTION
Don't merge this yet. I'm going to build this up with a bunch of commits fixing memory leaks. I'll document the ones being fixed as I go. Here's the first set:

```
==14544== 3 bytes in 1 blocks are definitely lost in loss record 16 of 2,400
==14544==    at 0x5550B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==14544==    by 0x63199B9: strdup (strdup.c:42)
==14544==    by 0x18933B: commify (in /usr/local/bin/doomretro)
==14544==    by 0x17FA2F: M_LoadCVARs (in /usr/local/bin/doomretro)
==14544==    by 0x16AC2F: D_DoomMainSetup (in /usr/local/bin/doomretro)
==14544==    by 0x16C36D: D_DoomMain (in /usr/local/bin/doomretro)
==14544==    by 0x16C39D: main (in /usr/local/bin/doomretro)
==14544== 
==14544== 3 bytes in 1 blocks are definitely lost in loss record 17 of 2,400
==14544==    at 0x5550B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==14544==    by 0x63199B9: strdup (strdup.c:42)
==14544==    by 0x18933B: commify (in /usr/local/bin/doomretro)
==14544==    by 0x17FA73: M_LoadCVARs (in /usr/local/bin/doomretro)
==14544==    by 0x16AC2F: D_DoomMainSetup (in /usr/local/bin/doomretro)
==14544==    by 0x16C36D: D_DoomMain (in /usr/local/bin/doomretro)
==14544==    by 0x16C39D: main (in /usr/local/bin/doomretro)

==14544== 4 bytes in 1 blocks are definitely lost in loss record 27 of 2,400
==14544==    at 0x5550B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==14544==    by 0x63199B9: strdup (strdup.c:42)
==14544==    by 0x18933B: commify (in /usr/local/bin/doomretro)
==14544==    by 0x17FA42: M_LoadCVARs (in /usr/local/bin/doomretro)
==14544==    by 0x16AC2F: D_DoomMainSetup (in /usr/local/bin/doomretro)
==14544==    by 0x16C36D: D_DoomMain (in /usr/local/bin/doomretro)
==14544==    by 0x16C39D: main (in /usr/local/bin/doomretro)
```