### PR TITLE
Fix compiling on mac for Doom Retro 3.0

### DIFF
--- a/src/c_autocomplete.c
+++ b/src/c_autocomplete.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ========================================================================
 
                            D O O M  R e t r o
@@ -6420,7 +6420,7 @@ autocomplete_t autocompletelist[] = {
     { "if vid_scaleapi opengl then ",                DOOM1AND2 },
     { "if vid_scaleapi software ",                   DOOM1AND2 },
     { "if vid_scaleapi software then ",              DOOM1AND2 },
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     { "if vid_scaleapi \"metal\" ",                  DOOM1AND2 },
     { "if vid_scaleapi \"metal\" then ",             DOOM1AND2 },
     { "if vid_scaleapi \"opengl\" ",                 DOOM1AND2 },
@@ -7482,7 +7482,7 @@ autocomplete_t autocompletelist[] = {
     { "vid_scaleapi direct3d",                       DOOM1AND2 },
     { "vid_scaleapi opengl",                         DOOM1AND2 },
     { "vid_scaleapi software",                       DOOM1AND2 },
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     { "vid_scaleapi \"metal\"",                      DOOM1AND2 },
     { "vid_scaleapi \"opengl\"",                     DOOM1AND2 },
     { "vid_scaleapi \"opengles\"",                   DOOM1AND2 },

--- a/src/c_cmds.c
+++ b/src/c_cmds.c
@@ -799,7 +799,7 @@ consolecmd_t consolecmds[] =
 #if defined(_WIN32)
     CVAR_STR(vid_scaleapi, "", vid_scaleapi_cvar_func1, vid_scaleapi_cvar_func2, CF_NONE,
         "The API used to scale the display (<b>\"direct3d\"</b>,\n<b>\"opengl\"</b> or <b>\"software\"</b>)."),
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     CVAR_STR(vid_scaleapi, "", vid_scaleapi_cvar_func1, vid_scaleapi_cvar_func2, CF_NONE,
         "The API used to scale the display (<b>\"metal\"</b>,\n<b>\"opengl\"</b>, <b>\"opengles\"</b>, <b>\"opengles2\"</b> or "
         "<b>\"software\"</b>)."),
@@ -2243,7 +2243,7 @@ static void help_cmd_func2(char *cmd, char *parms)
     ShellExecute(NULL, "open", PACKAGE_WIKI_HELP_URL, NULL, NULL, SW_SHOWNORMAL);
 #elif defined(__linux__)
     system("xdg-open "PACKAGE_WIKI_HELP_URL);
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     system("open "PACKAGE_WIKI_HELP_URL);
 #else
     C_HideConsoleFast();
@@ -6434,7 +6434,7 @@ static void vid_pillarboxes_cvar_func2(char *cmd, char *parms)
 static dboolean vid_scaleapi_cvar_func1(char *cmd, char *parms)
 {
     return (!*parms || M_StringCompare(parms, vid_scaleapi_direct3d)
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
         || M_StringCompare(parms, vid_scaleapi_metal)
 #endif
         || M_StringCompare(parms, vid_scaleapi_opengl)

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -544,7 +544,9 @@ void D_SetSaveGameFolder(dboolean output)
         savegamefolder_free = savegamefolder;
         savegamefolder = M_StringJoin(savegamefolder, (*pwadfile ? pwadfile : iwad_name), DIR_SEPARATOR_S, NULL);
 
+#if !defined(__APPLE__)
         free(appdatafolder);
+#endif
         free(savegamefolder_free);
     }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -755,7 +755,7 @@ static dboolean D_IsUnsupportedIWAD(char *filename)
     return false;
 }
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__MACOSX__)
 static dboolean D_IsCfgFile(char *filename)
 {
     return (M_StringCompare(filename + strlen(filename) - 4, ".cfg"));
@@ -1040,7 +1040,9 @@ static int D_OpenWADLauncher(void)
         dboolean    onlyoneselected;
 
         iwadfound = 0;
+#if defined(_WIN32)
         previouswad = M_StringDuplicate(wad);
+#endif
         wad = "";
         startuptimer = I_GetTimeMS();
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1604,7 +1604,10 @@ static void D_DoomMainSetup(void)
 
     M_MakeDirectory(appdatafolder);
     packageconfig = M_StringJoin(appdatafolder, DIR_SEPARATOR_S, PACKAGE_CONFIG, NULL);
+    
+#if !defined(__APPLE__)
     free(appdatafolder);
+#endif
 
     C_Output("");
     C_PrintCompileDate();

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -755,7 +755,6 @@ static dboolean D_IsUnsupportedIWAD(char *filename)
     return false;
 }
 
-#if defined(_WIN32) || defined(__APPLE__)
 static dboolean D_IsCfgFile(char *filename)
 {
     return (M_StringCompare(filename + strlen(filename) - 4, ".cfg"));
@@ -767,7 +766,6 @@ static dboolean D_IsDehFile(char *filename)
 
     return (M_StringCompare(filename + len - 4, ".deh") || M_StringCompare(filename + len - 4, ".bex"));
 }
-#endif
 
 static void D_CheckSupportedPWAD(char *filename)
 {

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -104,7 +104,7 @@ static char *iwadsrequired[] =
 char                *iwadfolder = iwadfolder_default;
 int                 turbo = turbo_default;
 int                 units = units_default;
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__APPLE__)
 char                *wad = wad_default;
 #endif
 dboolean            wipe = wipe_default;
@@ -755,7 +755,7 @@ static dboolean D_IsUnsupportedIWAD(char *filename)
     return false;
 }
 
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__APPLE__)
 static dboolean D_IsCfgFile(char *filename)
 {
     return (M_StringCompare(filename + strlen(filename) - 4, ".cfg"));
@@ -816,7 +816,7 @@ static dboolean D_IsUnsupportedPWAD(char *filename)
     return M_StringCompare(leafname(filename), "voices.wad");
 }
 
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
 #import <Cocoa/Cocoa.h>
 #endif
 
@@ -994,7 +994,7 @@ static dboolean D_CheckParms(void)
     return result;
 }
 
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__APPLE__)
 static int D_OpenWADLauncher(void)
 {
     int             iwadfound = -1;
@@ -1022,7 +1022,7 @@ static int D_OpenWADLauncher(void)
 
     error = false;
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     NSOpenPanel *panel = [NSOpenPanel openPanel];
 
     [panel setCanChooseFiles:YES];
@@ -1049,7 +1049,7 @@ static int D_OpenWADLauncher(void)
         // only one file was selected
 #if defined(_WIN32)
         onlyoneselected = !ofn.lpstrFile[lstrlen(ofn.lpstrFile) + 1];
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
         NSArray *urls = [panel URLs];
 
         onlyoneselected = ([urls count] == 1);
@@ -1059,7 +1059,7 @@ static int D_OpenWADLauncher(void)
         {
 #if defined(_WIN32)
             char    *file = (char *)ofn.lpstrFile;
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
             NSURL   *url = [urls objectAtIndex:0];
             char    *file = (char *)[url fileSystemRepresentation];
 #endif
@@ -1246,7 +1246,7 @@ static int D_OpenWADLauncher(void)
 
                 M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, iwadpass1);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
             char    *szFile;
 
             for (NSURL *url in urls)
@@ -1290,7 +1290,7 @@ static int D_OpenWADLauncher(void)
 
                 M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, iwadpass2);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
             for (NSURL *url in urls)
             {
                 char    *fullpath = (char *)[url fileSystemRepresentation];
@@ -1344,7 +1344,7 @@ static int D_OpenWADLauncher(void)
 
                     M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, pwadpass1);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
                 for (NSURL *url in urls)
                 {
                     char    *fullpath = (char *)[url fileSystemRepresentation];
@@ -1436,7 +1436,7 @@ static int D_OpenWADLauncher(void)
 
                         M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, pwadpass2);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
                     for (NSURL *url in urls)
                     {
                         char    *fullpath = (char *)[url fileSystemRepresentation];
@@ -1494,7 +1494,7 @@ static int D_OpenWADLauncher(void)
 
                     M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, cfgpass);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
                 for (NSURL *url in urls)
                 {
                     char    *fullpath = (char *)[url fileSystemRepresentation];
@@ -1517,7 +1517,7 @@ static int D_OpenWADLauncher(void)
 
                     M_snprintf(fullpath, sizeof(fullpath), "%s"DIR_SEPARATOR_S"%s", szFile, dehpass);
 
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
                 for (NSURL *url in urls)
                 {
                     char    *fullpath = (char *)[url fileSystemRepresentation];
@@ -1720,7 +1720,7 @@ static void D_DoomMainSetup(void)
         }
         else if (!p)
         {
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__APPLE__)
             do
             {
                 if ((choseniwad = D_OpenWADLauncher()) == -1)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1500,7 +1500,7 @@ static void SetVideoMode(dboolean output)
             if (output)
                 C_Output("The screen is rendered using hardware acceleration with the <i><b>OpenGL ES 2</b></i> API.");
         }
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
         else if (M_StringCompare(rendererinfo.name, vid_scaleapi_metal))
         {
             if (output)

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -845,7 +845,7 @@ static void M_CheckCVARs(void)
         vid_pillarboxes = vid_pillarboxes_default;
 
     if (!M_StringCompare(vid_scaleapi, vid_scaleapi_direct3d)
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
         && !M_StringCompare(vid_scaleapi, vid_scaleapi_metal)
 #endif
         && !M_StringCompare(vid_scaleapi, vid_scaleapi_opengl)

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -605,7 +605,7 @@ enum
 #define vid_pillarboxes_default                 false
 
 #define vid_scaleapi_direct3d                   "direct3d"
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
 #define vid_scaleapi_metal                      "metal"
 #endif
 #define vid_scaleapi_opengl                     "opengl"
@@ -636,7 +636,7 @@ enum
 
 #define vid_windowsize_default                  "768x480"
 
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__APPLE__)
 #define wad_default                             ""
 #endif
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1956,7 +1956,7 @@ void M_QuitDOOM(int choice)
 {
 #if defined(_WIN32)
     char        *OS = "Windows";
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     char        *OS = "OS X";
 #else
     char        *OS = "Linux";

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -64,7 +64,7 @@
 #include "version.h"
 #include "w_file.h"
 
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
 #import <Cocoa/Cocoa.h>
 #include <dirent.h>
 #include <libgen.h>
@@ -179,7 +179,7 @@ char *M_GetAppDataFolder(void)
     {
         closedir(resourcedir);
 
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
         // On OSX, store generated application files in ~/Library/Application Support/DOOM Retro.
         NSFileManager   *manager = [NSFileManager defaultManager];
         NSURL           *baseAppSupportURL = [manager URLsForDirectory : NSApplicationSupportDirectory
@@ -221,7 +221,7 @@ char *M_GetResourceFolder(void)
         return resourcefolder;
     }
 
-#if defined(__MACOSX__)
+#if defined(__APPLE__)
     // On OSX, load resources from the Contents/Resources folder within the application bundle
     // if ../share/doomretro is not available.
     NSURL   *resourceURL = [NSBundle mainBundle].resourceURL;
@@ -284,7 +284,7 @@ char *M_GetExecutableFolder(void)
         strcpy(exe, ".");
         return exe;
     }
-#elif defined(__MACOSX__)
+#elif defined(__APPLE__)
     char        *exe = malloc(MAX_PATH);
     uint32_t    len = MAX_PATH;
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1492,7 +1492,9 @@ void V_Init(void)
         char    *appdatafolder = M_GetAppDataFolder();
 
         M_snprintf(screenshotfolder, sizeof(screenshotfolder), "%s"DIR_SEPARATOR_S"screenshots", appdatafolder);
+#if !defined(__MACOSX__)
         free(appdatafolder);
+#endif
     }
 }
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1492,7 +1492,7 @@ void V_Init(void)
         char    *appdatafolder = M_GetAppDataFolder();
 
         M_snprintf(screenshotfolder, sizeof(screenshotfolder), "%s"DIR_SEPARATOR_S"screenshots", appdatafolder);
-#if !defined(__MACOSX__)
+#if !defined(__APPLE__)
         free(appdatafolder);
 #endif
     }


### PR DESCRIPTION
I made a few changes to get the current state of the repository compiling and running on macOS:

- There were a couple of filename helper functions (specifically `D_IsCfgFile` and `D_IsDehFile`) that were missing when compiled for anything other than windows. These seemed pretty innocent and were used in locations that were not being wrapped in OS macros anyway.

- Wrapped a reference to `previouswad` in a Windows macro as it was being referenced for all OS targets when it was only originally defined for Windows.

- Removed a `free()` allocation call in `V_Init` when running on mac. This was something added in this pull request: #509. However, based on the comments in the pull request this was unable to be tested on mac? Well this particular `free()` was causing a signal abort crash on mac. Removing it fixes the crash and allows the game to run.
  > I'm unsure if this `free()` call is useful for Windows and Linux so i opted to wrap it in a macro in case it matters on those platforms.

- I also have renamed all `__MACOSX__` macros to `__APPLE__`. I discovered an issue when compile on my mac machine (macOS Mojave v10.14.5) that it seemed to ignore the __MACOSX__ macro when compiling in XCode. In particular, i tried wrapping the above fix for the `V_Init free()` call with the `__MACOSX__` but the game would still crash. Replacing it with `__APPLE__` fixed it. 
  > I searched online for what macros is more generally supported for Apple platforms and discovered this stack overflow thread: [https://stackoverflow.com/questions/2166483/which-macro-to-wrap-mac-os-x-specific-code-in-c-c](url). The concensus seems to be that `__APPLE__` is more generally supported. And if you really wanted to narrow it down to macOS only (ie ignore iOS) you could use something like this: `#if defined(__APPLE__) && defined(__MACH__)`
