### PR TITLE
Fixed building on mac

### DIFF
--- a/src/m_config.h
+++ b/src/m_config.h
@@ -210,7 +210,7 @@ extern dboolean     vid_vsync;
 extern dboolean     vid_widescreen;
 extern char         *vid_windowpos;
 extern char         *vid_windowsize;
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__APPLE__)
 extern char         *wad;
 #endif
 extern int          weaponbob;


### PR DESCRIPTION
`m_config` `wad` was not being defined on mac during compilation despite it being referenced elsewhere in the codebase on mac.