### PR TITLE
Fix linking on newer GNU/Linux systems by correcting linker parameter…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ SRCS := $(shell find . -name '*.c')
 OBJS = $(patsubst %.c,%.o,$(SRCS))
 
 doomretro : $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
+	$(CC) $^ -o $@ $(CFLAGS) $(LDFLAGS)
 
 %.o : %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
…s order.

I was getting:
```

cc -O2 `sdl2-config --cflags` `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lm r_draw.o v_data.o c_cmds.o f_wipe.o d_iwad.o doomstat.o d_main.o p_tick.o m_bbox.o f_finale.o i_sound.o i_midirpc.o hu_lib.o d_loop.o sprites.o p_spec.o m_cheat.o v_video.o hu_stuff.o states.o m_menu.o p_sight.o p_saveg.o p_fix.o sc_man.o r_sky.o p_pspr.o p_map.o doomretro.o p_lights.o m_misc.o c_console.o p_user.o p_setup.o sounds.o wi_stuff.o s_sound.o p_floor.o d_deh.o p_switch.o r_bsp.o w_file.o p_plats.o r_plane.o p_genlin.o m_argv.o i_music.o info.o i_timer.o p_maputl.o i_gamepad.o r_data.o st_stuff.o z_zone.o dstrings.o i_colors.o p_telept.o r_segs.o d_items.o st_lib.o g_game.o c_autocomplete.o p_enemy.o r_things.o i_system.o p_doors.o r_main.o w_wad.o m_controls.o p_mobj.o m_config.o w_merge.o am_map.o mmus2mid.o p_ceilng.o r_patch.o p_inter.o i_video.o -o doomretro
d_main.o: In function `D_DoomMainSetup':
d_main.c:(.text+0x2382): undefined reference to `SDL_ShowSimpleMessageBox'
m_menu.o: In function `M_SaveSelect':
m_menu.c:(.text+0x3120): undefined reference to `SDL_StartTextInput'
m_menu.o: In function `M_Responder':
m_menu.c:(.text+0x5086): undefined reference to `SDL_GetModState'
m_menu.c:(.text+0x5268): undefined reference to `SDL_GetModState'
m_menu.c:(.text+0x5528): undefined reference to `SDL_StopTextInput'
m_menu.c:(.text+0x562f): undefined reference to `SDL_StopTextInput'
m_menu.c:(.text+0x5c7c): undefined reference to `SDL_GetModState'
m_menu.o: In function `M_SetWindowCaption':
m_menu.c:(.text+0x2820): undefined reference to `SDL_SetWindowTitle'
c_cmds.o: In function `resetall_cmd_func2':
c_cmds.c:(.text+0x3a4e): undefined reference to `SDL_StopTextInput'
c_cmds.o: In function `mapstats_cmd_func2':
c_cmds.c:(.text+0x6199): undefined reference to `Mix_GetMusicType'
c_cmds.o: In function `vid_windowpos_cvar_func2':
c_cmds.c:(.text+0x96eb): undefined reference to `SDL_SetWindowPosition'
c_cmds.o: In function `vid_showfps_cvar_func2':
c_cmds.c:(.text+0x9ce1): undefined reference to `SDL_GetPerformanceCounter'
c_cmds.o: In function `C_VerifyResetAll':
c_cmds.c:(.text+0xb7f7): undefined reference to `SDL_StartTextInput'
c_cmds.o: In function `vid_windowsize_cvar_func2':
c_cmds.c:(.text+0x961c): undefined reference to `SDL_SetWindowSize'
d_iwad.o: In function `BuildIWADDirList.part.0':
d_iwad.c:(.text+0x9): undefined reference to `SDL_getenv'
d_iwad.c:(.text+0x2a): undefined reference to `SDL_getenv'
i_sound.o: In function `ReleaseSoundOnChannel':
i_sound.c:(.text+0x359): undefined reference to `Mix_HaltChannel'
i_sound.o: In function `I_StartSound':
i_sound.c:(.text+0x512): undefined reference to `Mix_PlayChannelTimed'
i_sound.c:(.text+0x55b): undefined reference to `Mix_SetPanning'
i_sound.o: In function `I_UpdateSound':
i_sound.c:(.text+0x719): undefined reference to `Mix_Playing'
i_sound.o: In function `I_ShutdownSound':
i_sound.c:(.text+0x775): undefined reference to `Mix_CloseAudio'
i_sound.c:(.text+0x77f): undefined reference to `SDL_QuitSubSystem'
i_sound.o: In function `I_InitSound':
i_sound.c:(.text+0x7b6): undefined reference to `Mix_Linked_Version'
i_sound.c:(.text+0x7e6): undefined reference to `SDL_InitSubSystem'
i_sound.c:(.text+0x83e): undefined reference to `Mix_OpenAudio'
i_sound.c:(.text+0x858): undefined reference to `Mix_QuerySpec'
i_sound.c:(.text+0x8b5): undefined reference to `Mix_AllocateChannels'
i_sound.c:(.text+0x8bc): undefined reference to `SDL_PauseAudio'
i_sound.o: In function `I_UpdateSoundParms':
i_sound.c:(.text+0x495): undefined reference to `Mix_SetPanning'
i_sound.o: In function `I_SoundIsPlaying':
i_sound.c:(.text+0x6d1): undefined reference to `Mix_Playing'
i_sound.o: In function `I_AnySoundStillPlaying':
i_sound.c:(.text+0x756): undefined reference to `Mix_Playing'
v_video.o: In function `V_SavePNG':
v_video.c:(.text+0x27): undefined reference to `SDL_GetRendererOutputSize'
v_video.c:(.text+0x7c): undefined reference to `SDL_CreateRGBSurface'
v_video.c:(.text+0x9e): undefined reference to `SDL_RenderReadPixels'
v_video.c:(.text+0xae): undefined reference to `SDL_FreeSurface'
v_video.c:(.text+0x139): undefined reference to `IMG_SavePNG'
v_video.o: In function `V_Init':
v_video.c:(.text+0x3574): undefined reference to `IMG_Linked_Version'
p_map.o: In function `P_TryMove':
p_map.c:(.text+0x2ccf): undefined reference to `hypot'
m_misc.o: In function `M_GetAppDataFolder':
m_misc.c:(.text+0x48a): undefined reference to `SDL_getenv'
c_console.o: In function `C_HideConsole.part.0':
c_console.c:(.text+0x1c5): undefined reference to `SDL_StopTextInput'
c_console.o: In function `C_HideConsoleFast':
c_console.c:(.text+0x2dd5): undefined reference to `SDL_StopTextInput'
c_console.o: In function `C_ValidateInput':
c_console.c:(.text+0x4cfa): undefined reference to `SDL_StopTextInput'
c_console.o: In function `C_Responder':
c_console.c:(.text+0x5046): undefined reference to `SDL_GetModState'
c_console.c:(.text+0x558b): undefined reference to `SDL_GetClipboardText'
c_console.c:(.text+0x5635): undefined reference to `SDL_GetClipboardText'
c_console.c:(.text+0x5b5b): undefined reference to `SDL_SetClipboardText'
c_console.c:(.text+0x5e03): undefined reference to `SDL_SetClipboardText'
c_console.o: In function `C_PrintSDLVersions':
c_console.c:(.text+0x6722): undefined reference to `SDL_GetRevisionNumber'
c_console.o: In function `C_ShowConsole':
c_console.c:(.text+0x2d76): undefined reference to `SDL_StartTextInput'
p_setup.o: In function `GetOffset':
p_setup.c:(.text+0x55d): undefined reference to `sqrt'
p_setup.o: In function `P_SetupLevel':
p_setup.c:(.text+0x4646): undefined reference to `sqrt'
wi_stuff.o: In function `WI_CheckForAccelerate':
wi_stuff.c:(.text+0xf37): undefined reference to `SDL_GetKeyboardState'
s_sound.o: In function `S_Init':
s_sound.c:(.text+0x81d): undefined reference to `SDL_GetCurrentAudioDriver'
s_sound.o: In function `S_ChangeMusic':
s_sound.c:(.text+0xfc4): undefined reference to `Mix_LoadMUS'
i_music.o: In function `I_ShutdownMusic':
i_music.c:(.text+0x1a): undefined reference to `Mix_FadeOutMusic'
i_music.c:(.text+0x21): undefined reference to `Mix_PlayingMusic'
i_music.c:(.text+0x34): undefined reference to `Mix_CloseAudio'
i_music.o: In function `I_InitMusic':
i_music.c:(.text+0x75): undefined reference to `Mix_QuerySpec'
i_music.c:(.text+0x85): undefined reference to `SDL_InitSubSystem'
i_music.c:(.text+0xa2): undefined reference to `Mix_OpenAudio'
i_music.c:(.text+0xb2): undefined reference to `SDL_PauseAudio'
i_music.c:(.text+0xe6): undefined reference to `SDL_QuitSubSystem'
i_music.o: In function `I_PauseSong':
i_music.c:(.text+0x15e): undefined reference to `Mix_VolumeMusic'
i_music.o: In function `I_RegisterSong':
i_music.c:(.text+0x262): undefined reference to `SDL_RWFromMem'
i_music.c:(.text+0x275): undefined reference to `Mix_LoadMUS_RW'
i_music.o: In function `I_ShutdownMusic':
i_music.c:(.text+0x42): undefined reference to `SDL_QuitSubSystem'
i_music.o: In function `I_SetMusicVolume':
i_music.c:(.text+0x101): undefined reference to `Mix_VolumeMusic'
i_music.o: In function `I_PlaySong':
i_music.c:(.text+0x12b): undefined reference to `Mix_PlayMusic'
i_music.o: In function `I_PauseSong':
i_music.c:(.text+0x16f): undefined reference to `Mix_VolumeMusic'
i_music.c:(.text+0x179): undefined reference to `Mix_PauseMusic'
i_music.o: In function `I_ResumeSong':
i_music.c:(.text+0x1ab): undefined reference to `Mix_VolumeMusic'
i_music.c:(.text+0x1b1): undefined reference to `Mix_ResumeMusic'
i_music.o: In function `I_StopSong':
i_music.c:(.text+0x1d1): undefined reference to `Mix_HaltMusic'
i_music.o: In function `I_UnRegisterSong':
i_music.c:(.text+0x1f9): undefined reference to `Mix_FreeMusic'
i_timer.o: In function `I_GetTime':
i_timer.c:(.text+0x5): undefined reference to `SDL_GetTicks'
i_timer.o: In function `I_GetTimeMS':
i_timer.c:(.text+0x21): undefined reference to `SDL_GetTicks'
i_timer.o: In function `I_Sleep':
i_timer.c:(.text+0x31): undefined reference to `SDL_Delay'
i_timer.o: In function `I_InitTimer':
i_timer.c:(.text+0x46): undefined reference to `SDL_InitSubSystem'
i_timer.o: In function `I_ShutdownTimer':
i_timer.c:(.text+0x56): undefined reference to `SDL_QuitSubSystem'
i_gamepad.o: In function `I_InitGamepad':
i_gamepad.c:(.text+0xc): undefined reference to `SDL_InitSubSystem'
i_gamepad.c:(.text+0x19): undefined reference to `SDL_NumJoysticks'
i_gamepad.c:(.text+0x2b): undefined reference to `SDL_JoystickOpen'
i_gamepad.c:(.text+0x3e): undefined reference to `SDL_IsGameController'
i_gamepad.c:(.text+0x62): undefined reference to `SDL_GameControllerName'
i_gamepad.c:(.text+0x106): undefined reference to `SDL_HapticOpenFromJoystick'
i_gamepad.c:(.text+0x11a): undefined reference to `SDL_HapticRumbleInit'
i_gamepad.c:(.text+0x136): undefined reference to `SDL_SetHintWithPriority'
i_gamepad.c:(.text+0x163): undefined reference to `SDL_GameControllerOpen'
i_gamepad.c:(.text+0x180): undefined reference to `SDL_QuitSubSystem'
i_gamepad.o: In function `I_ShutdownGamepad':
i_gamepad.c:(.text+0x1d4): undefined reference to `SDL_HapticClose'
i_gamepad.c:(.text+0x209): undefined reference to `SDL_GameControllerClose'
i_gamepad.c:(.text+0x220): undefined reference to `SDL_JoystickClose'
i_gamepad.c:(.text+0x239): undefined reference to `SDL_QuitSubSystem'
i_gamepad.o: In function `I_GamepadVibration':
i_gamepad.c:(.text+0x2b2): undefined reference to `SDL_HapticRumblePlay'
i_gamepad.o: In function `I_StopGamepadVibration':
i_gamepad.c:(.text+0x36d): undefined reference to `SDL_HapticRumbleStop'
g_game.o: In function `G_BuildTiccmd':
g_game.c:(.text+0xaf0): undefined reference to `powf'
g_game.c:(.text+0xb75): undefined reference to `powf'
g_game.c:(.text+0xbfb): undefined reference to `powf'
g_game.c:(.text+0xc76): undefined reference to `powf'
g_game.c:(.text+0xce8): undefined reference to `powf'
g_game.o:g_game.c:(.text+0xd87): more undefined references to `powf' follow
i_system.o: In function `I_PrintSystemInfo':
i_system.c:(.text+0x7): undefined reference to `SDL_GetCPUCount'
i_system.c:(.text+0xe): undefined reference to `SDL_GetSystemRAM'
i_system.o: In function `I_Error':
i_system.c:(.text+0x270): undefined reference to `SDL_ShowSimpleMessageBox'
r_main.o: In function `R_Init':
r_main.c:(.text+0x1329): undefined reference to `atan'
r_main.c:(.text+0x139d): undefined reference to `tan'
r_main.c:(.text+0x1405): undefined reference to `sin'
am_map.o: In function `AM_Responder':
am_map.c:(.text+0x1a74): undefined reference to `SDL_GetModState'
am_map.c:(.text+0x1bb0): undefined reference to `atan2'
am_map.c:(.text+0x21ea): undefined reference to `powf'
am_map.c:(.text+0x24d3): undefined reference to `powf'
am_map.c:(.text+0x258f): undefined reference to `powf'
am_map.c:(.text+0x2724): undefined reference to `powf'
am_map.c:(.text+0x27ff): undefined reference to `powf'
am_map.o:am_map.c:(.text+0x29c5): more undefined references to `powf' follow
am_map.o: In function `AM_Drawer':
am_map.c:(.text+0x42ec): undefined reference to `sqrt'
am_map.c:(.text+0x4300): undefined reference to `sqrt'
i_video.o: In function `I_Blit_Automap':
i_video.c:(.text+0x1d): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x40): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x4c): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x68): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_Automap_NearestLinear':
i_video.c:(.text+0x9d): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0xc0): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0xcc): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0xdf): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0xfb): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x109): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x120): undefined reference to `SDL_RenderCopy'
i_video.o: In function `CalculateFPS':
i_video.c:(.text+0x145): undefined reference to `SDL_GetPerformanceCounter'
i_video.o: In function `GetDisplays':
i_video.c:(.text+0x1b7): undefined reference to `SDL_GetNumVideoDisplays'
i_video.c:(.text+0x1ea): undefined reference to `SDL_GetDisplayBounds'
i_video.o: In function `UpdateGrab':
i_video.c:(.text+0x2e7): undefined reference to `SDL_SetRelativeMouseMode'
i_video.c:(.text+0x2f0): undefined reference to `SDL_GetRelativeMouseState'
i_video.c:(.text+0x318): undefined reference to `SDL_WarpMouseInWindow'
i_video.c:(.text+0x321): undefined reference to `SDL_GetRelativeMouseState'
i_video.c:(.text+0x336): undefined reference to `SDL_SetRelativeMouseMode'
i_video.c:(.text+0x33f): undefined reference to `SDL_GetRelativeMouseState'
i_video.o: In function `I_Blit':
i_video.c:(.text+0x372): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x395): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x3a1): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x3bd): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_NearestLinear':
i_video.c:(.text+0x402): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x425): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x431): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x444): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x460): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x46e): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x485): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_ShowFPS':
i_video.c:(.text+0x4c7): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x4ea): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x4f6): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x512): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_NearestLinear_ShowFPS':
i_video.c:(.text+0x557): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x57a): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x586): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x599): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x5b5): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x5c3): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x5da): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_Shake':
i_video.c:(.text+0x612): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x635): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x641): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x65d): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x6d2): undefined reference to `SDL_RenderCopyEx'
i_video.o: In function `I_Blit_NearestLinear_Shake':
i_video.c:(.text+0x712): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x735): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x741): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x754): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x770): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x7e5): undefined reference to `SDL_RenderCopyEx'
i_video.c:(.text+0x7f3): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x80a): undefined reference to `SDL_RenderCopy'
i_video.o: In function `I_Blit_ShowFPS_Shake':
i_video.c:(.text+0x847): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x86a): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x876): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x892): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0x907): undefined reference to `SDL_RenderCopyEx'
i_video.o: In function `I_Blit_NearestLinear_ShowFPS_Shake':
i_video.c:(.text+0x947): undefined reference to `SDL_LowerBlit'
i_video.c:(.text+0x96a): undefined reference to `SDL_UpdateTexture'
i_video.c:(.text+0x976): undefined reference to `SDL_RenderClear'
i_video.c:(.text+0x989): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0x9a5): undefined reference to `SDL_RenderCopy'
i_video.c:(.text+0xa1a): undefined reference to `SDL_RenderCopyEx'
i_video.c:(.text+0xa28): undefined reference to `SDL_SetRenderTarget'
i_video.c:(.text+0xa3f): undefined reference to `SDL_RenderCopy'
i_video.o: In function `keystate':
i_video.c:(.text+0xa67): undefined reference to `SDL_GetKeyboardState'
i_video.o: In function `GetCapsLockState':
i_video.c:(.text+0xd35): undefined reference to `SDL_GetModState'
i_video.o: In function `I_SetPalette':
i_video.c:(.text+0xfb3): undefined reference to `SDL_SetPaletteColors'
i_video.c:(.text+0x1009): undefined reference to `sqrt'
i_video.o: In function `I_SetExternalAutomapPalette':
i_video.c:(.text+0x10ff): undefined reference to `SDL_SetPaletteColors'
i_video.o: In function `I_SetPaletteWithBrightness':
i_video.c:(.text+0x12cf): undefined reference to `SDL_SetPaletteColors'
i_video.c:(.text+0x132b): undefined reference to `sqrt'
i_video.o: In function `I_CreateExternalAutomap':
i_video.c:(.text+0x14fc): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x1536): undefined reference to `SDL_CreateWindow'
i_video.c:(.text+0x154f): undefined reference to `SDL_CreateRenderer'
i_video.c:(.text+0x1568): undefined reference to `SDL_RenderSetLogicalSize'
i_video.c:(.text+0x1588): undefined reference to `SDL_CreateRGBSurface'
i_video.c:(.text+0x159b): undefined reference to `SDL_GetWindowPixelFormat'
i_video.c:(.text+0x15bb): undefined reference to `SDL_PixelFormatEnumToMasks'
i_video.c:(.text+0x15e4): undefined reference to `SDL_CreateRGBSurface'
i_video.c:(.text+0x15fb): undefined reference to `SDL_FillRect'
i_video.c:(.text+0x161c): undefined reference to `SDL_CreateTexture'
i_video.c:(.text+0x1649): undefined reference to `SDL_AllocPalette'
i_video.c:(.text+0x165f): undefined reference to `SDL_SetSurfacePalette'
i_video.c:(.text+0x1679): undefined reference to `SDL_SetPaletteColors'
i_video.c:(.text+0x16ac): undefined reference to `SDL_GetDisplayName'
i_video.c:(.text+0x16e4): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x1711): undefined reference to `SDL_CreateTexture'
i_video.o: In function `I_DestroyExternalAutomap':
i_video.c:(.text+0x175c): undefined reference to `SDL_FreePalette'
i_video.c:(.text+0x1768): undefined reference to `SDL_FreeSurface'
i_video.c:(.text+0x1774): undefined reference to `SDL_FreeSurface'
i_video.c:(.text+0x1780): undefined reference to `SDL_DestroyTexture'
i_video.c:(.text+0x178c): undefined reference to `SDL_DestroyTexture'
i_video.c:(.text+0x1798): undefined reference to `SDL_DestroyRenderer'
i_video.c:(.text+0x17a4): undefined reference to `SDL_DestroyWindow'
i_video.o: In function `GetScreenResolution':
i_video.c:(.text+0x1c01): undefined reference to `SDL_GetNumDisplayModes'
i_video.c:(.text+0x1c2b): undefined reference to `SDL_GetDisplayMode'
i_video.o: In function `SetVideoMode':
i_video.c:(.text+0x1cbf): undefined reference to `SDL_GetDisplayName'
i_video.c:(.text+0x1d5f): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x1e34): undefined reference to `SDL_CreateWindow'
i_video.c:(.text+0x1ea6): undefined reference to `SDL_GetDisplayName'
i_video.c:(.text+0x1ef8): undefined reference to `SDL_CreateWindow'
i_video.c:(.text+0x1fa5): undefined reference to `SDL_GetWindowID'
i_video.c:(.text+0x1fc5): undefined reference to `SDL_GetWindowSize'
i_video.c:(.text+0x1fd9): undefined reference to `SDL_CreateRenderer'
i_video.c:(.text+0x1ffb): undefined reference to `SDL_RenderSetLogicalSize'
i_video.c:(.text+0x2015): undefined reference to `SDL_GetRendererInfo'
i_video.c:(.text+0x203d): undefined reference to `SDL_CreateRGBSurface'
i_video.c:(.text+0x205b): undefined reference to `SDL_GetWindowPixelFormat'
i_video.c:(.text+0x207b): undefined reference to `SDL_PixelFormatEnumToMasks'
i_video.c:(.text+0x20a4): undefined reference to `SDL_CreateRGBSurface'
i_video.c:(.text+0x20bb): undefined reference to `SDL_FillRect'
i_video.c:(.text+0x20ea): undefined reference to `SDL_CreateTexture'
i_video.c:(.text+0x2113): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x2140): undefined reference to `SDL_CreateTexture'
i_video.c:(.text+0x2151): undefined reference to `SDL_AllocPalette'
i_video.c:(.text+0x2167): undefined reference to `SDL_SetSurfacePalette'
i_video.c:(.text+0x21fb): undefined reference to `SDL_CreateWindow'
i_video.c:(.text+0x22c4): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x2309): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x233c): undefined reference to `SDL_GL_GetAttribute'
i_video.c:(.text+0x234b): undefined reference to `SDL_GL_GetAttribute'
i_video.c:(.text+0x239b): undefined reference to `SDL_GL_GetProcAddress'
i_video.c:(.text+0x24d9): undefined reference to `SDL_GetRendererInfo'
i_video.c:(.text+0x25f2): undefined reference to `SDL_CreateRenderer'
i_video.c:(.text+0x26ec): undefined reference to `SDL_GetWindowDisplayMode'
i_video.c:(.text+0x2813): undefined reference to `SDL_CreateWindow'
i_video.c:(.text+0x2a01): undefined reference to `SDL_SetHintWithPriority'
i_video.c:(.text+0x2b57): undefined reference to `SDL_GL_SetSwapInterval'
i_video.o: In function `I_SetMotionBlur':
i_video.c:(.text+0x2c07): undefined reference to `SDL_SetSurfaceAlphaMod'
i_video.c:(.text+0x2c3c): undefined reference to `SDL_SetSurfaceAlphaMod'
i_video.o: In function `I_ToggleWidescreen':
i_video.c:(.text+0x2c8c): undefined reference to `SDL_RenderSetLogicalSize'
i_video.c:(.text+0x2ca2): undefined reference to `SDL_RenderSetLogicalSize'
i_video.c:(.text+0x2d06): undefined reference to `SDL_RenderSetLogicalSize'
i_video.c:(.text+0x2d1c): undefined reference to `SDL_RenderSetLogicalSize'
i_video.o: In function `I_RestartGraphics':
i_video.c:(.text+0x2d3c): undefined reference to `SDL_FreePalette'
i_video.c:(.text+0x2d48): undefined reference to `SDL_FreeSurface'
i_video.c:(.text+0x2d54): undefined reference to `SDL_FreeSurface'
i_video.c:(.text+0x2d60): undefined reference to `SDL_DestroyTexture'
i_video.c:(.text+0x2d6c): undefined reference to `SDL_DestroyTexture'
i_video.c:(.text+0x2d78): undefined reference to `SDL_DestroyRenderer'
i_video.c:(.text+0x2d84): undefined reference to `SDL_DestroyWindow'
i_video.o: In function `I_ToggleFullscreen':
i_video.c:(.text+0x2e0d): undefined reference to `SDL_SetWindowFullscreen'
i_video.c:(.text+0x2eb3): undefined reference to `SDL_SetWindowSize'
i_video.c:(.text+0x2ef9): undefined reference to `SDL_SetWindowPosition'
i_video.c:(.text+0x2ffe): undefined reference to `SDL_SetWindowPosition'
i_video.o: In function `I_StartTic':
i_video.c:(.text+0x3051): undefined reference to `SDL_PumpEvents'
i_video.c:(.text+0x305c): undefined reference to `SDL_PollEvent'
i_video.c:(.text+0x3128): undefined reference to `SDL_PollEvent'
i_video.c:(.text+0x313f): undefined reference to `SDL_GetRelativeMouseState'
i_video.c:(.text+0x3614): undefined reference to `SDL_IsTextInputActive'
i_video.c:(.text+0x363c): undefined reference to `SDL_IsTextInputActive'
i_video.c:(.text+0x3926): undefined reference to `SDL_GetModState'
i_video.c:(.text+0x3a36): undefined reference to `SDL_GetWindowDisplayIndex'
i_video.c:(.text+0x3a6d): undefined reference to `SDL_SetPaletteColors'
i_video.o: In function `I_InitGraphics':
i_video.c:(.text+0x3c90): undefined reference to `SDL_GetVersion'
i_video.c:(.text+0x3d06): undefined reference to `SDL_GetPerformanceFrequency'
i_video.c:(.text+0x3e27): undefined reference to `pow'
i_video.c:(.text+0x3e81): undefined reference to `SDL_setenv'
i_video.c:(.text+0x3e8b): undefined reference to `SDL_InitSubSystem'
i_video.c:(.text+0x3eae): undefined reference to `SDL_SetRelativeMouseMode'
i_video.c:(.text+0x3eb7): undefined reference to `SDL_GetRelativeMouseState'
i_video.c:(.text+0x3eea): undefined reference to `SDL_SetWindowTitle'
i_video.c:(.text+0x3f17): undefined reference to `SDL_PollEvent'
i_video.o: In function `I_Blit_Automap':
i_video.c:(.text+0x78): undefined reference to `SDL_RenderPresent'
i_video.o: In function `I_Blit_Automap_NearestLinear':
i_video.c:(.text+0x130): undefined reference to `SDL_RenderPresent'
i_video.o: In function `I_Blit':
i_video.c:(.text+0x3cd): undefined reference to `SDL_RenderPresent'
i_video.o: In function `I_Blit_NearestLinear':
i_video.c:(.text+0x495): undefined reference to `SDL_RenderPresent'
i_video.o: In function `I_Blit_ShowFPS':
i_video.c:(.text+0x522): undefined reference to `SDL_RenderPresent'
i_video.o:i_video.c:(.text+0x5ea): more undefined references to `SDL_RenderPresent' follow
i_video.o: In function `I_ShutdownGraphics':
i_video.c:(.text+0xd26): undefined reference to `SDL_QuitSubSystem'
i_video.o: In function `I_SetPalette':
i_video.c:(.text+0x1077): undefined reference to `SDL_SetRenderDrawColor'
i_video.o: In function `I_SetSimplePalette':
i_video.c:(.text+0x1167): undefined reference to `SDL_SetPaletteColors'
i_video.o: In function `I_SetPaletteWithBrightness':
i_video.c:(.text+0x139f): undefined reference to `SDL_SetRenderDrawColor'
i_video.o: In function `I_SetMotionBlur':
i_video.c:(.text+0x2c19): undefined reference to `SDL_SetSurfaceBlendMode'
i_video.c:(.text+0x2c51): undefined reference to `SDL_SetSurfaceBlendMode'
i_video.o: In function `I_ToggleWidescreen':
i_video.c:(.text+0x2cde): undefined reference to `SDL_SetPaletteColors'
i_video.o: In function `I_ToggleFullscreen':
i_video.c:(.text+0x2f51): undefined reference to `SDL_WarpMouseInWindow'
i_video.o: In function `I_SetPillarboxes':
i_video.c:(.text+0x3b78): undefined reference to `SDL_SetRenderDrawColor'
i_video.o: In function `I_InitKeyboard':
i_video.c:(.text+0x3c61): undefined reference to `SDL_GetModState'
collect2: error: ld returned 1 exit status
Makefile:55: recipe for target 'doomretro' failed
make: *** [doomretro] Error 1

```

So this puts the CFLAGS and LDFLAGS where they belong (after the objects list, not before).
GCC seems to has become serious about this (no idea when, but it has).