### PR TITLE
Fix: Autosave name doesn't update correctly with (U)MAPINFO

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1183,6 +1183,8 @@ void M_UpdateSaveGameName(int i)
             int map;
 
             if (M_CheckSaveGame(&ep, &map, i))
+                if (M_StringCompare(savegamestrings[i], P_GetMapName(map)))
+                    match = true;
                 switch (gamemission)
                 {
                     case doom:
@@ -3762,8 +3764,8 @@ void M_Drawer(void)
                     }
                     else if (M_StringCompare(name, "M_MSENS") && !M_MSENS)
                         M_DrawString(x, y + OFFSET, (usinggamepad ? s_M_GAMEPADSENSITIVITY : s_M_MOUSESENSITIVITY));
-                    else if (W_CheckNumForName(name) < 0)   // Custom Episode
-                        M_WriteText(x, y + OFFSET, *text, true);
+                    else if (W_CheckNumForName(name) < 0 && **text)   // Custom Episode
+                        M_DrawString(x, y + OFFSET, *text);
                     else if (W_CheckMultipleLumps(name) > 1 || lumpinfo[W_GetNumForName(name)]->wadfile->type == PWAD)
                         M_DrawPatchWithShadow(x, y + OFFSET, W_CacheLumpName(name));
                     else if (**text)


### PR DESCRIPTION
If UMAPINFO is the only source of level names, like in dbp25-dead_but_dreaming-v2g.wad