### PR TITLE
Add EndGameC support to MAPINFO

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -153,6 +153,13 @@ void F_StartFinale(void)
         else
             S_ChangeMusic((gamemode == commercial ? mus_read_m : mus_victor), true, false, false);
     }
+    else if (P_GetMapEndCast(gamemap))
+    {
+        gameaction = ga_nothing;
+        gamestate = GS_FINALE;
+        F_StartCast();
+        return;
+    }
     else
         // Okay - IWAD dependent stuff.
         // This has been changed severely, and

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1358,6 +1358,12 @@ void G_WorldDone(void)
         return;
     }
 
+    if (P_GetMapEndCast(gamemap))
+    {
+        F_StartFinale();
+        return;
+    }
+
     if (gamemode == commercial)
     {
         if (gamemission == pack_nerve)

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -3288,6 +3288,11 @@ static void P_InitMapInfo(void)
                             int nextmap = -1;
 
                             SC_MustGetString();
+                            if (SC_Compare("ENDGAMEC"))
+                            {
+                                info->endcast = true;
+                                break;
+                            }
                             sscanf(sc_String, "%i", &nextmap);
 
                             if (nextmap < 0 || nextmap > 99)

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -727,7 +727,7 @@ static void WI_UpdateShowNextLoc(void)
 
 static void WI_DrawShowNextLoc(void)
 {
-    if (P_GetMapEndGame(gamemap))
+    if (P_GetMapEndGame(gamemap) || P_GetMapEndCast(gamemap))
         return;
 
     WI_SlamBackground();


### PR DESCRIPTION
Pair next = "endgamec" used in some PWADs for the end game. Avactor map12 for example.