### PR TITLE
Sound system fix for haiku.

### DIFF
--- a/src/i_music.c
+++ b/src/i_music.c
@@ -89,12 +89,13 @@ dboolean I_InitMusic(void)
 
     // If SDL_mixer is not initialized, we have to initialize it
     // and have the responsibility to shut it down later on.
+    freq = MIX_DEFAULT_FREQUENCY;
     if (!Mix_QuerySpec(&freq, &format, &channels))
     {
         if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
             return false;
 
-        if (Mix_OpenAudioDevice(SAMPLERATE, MIX_DEFAULT_FORMAT, CHANNELS, CHUNKSIZE, NULL, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
+        if (Mix_OpenAudioDevice(SAMPLERATE, MIX_DEFAULT_FORMAT, CHANNELS, CHUNKSIZE, DEFAULT_DEVICE, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
         {
             SDL_QuitSubSystem(SDL_INIT_AUDIO);
             return false;

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -63,7 +63,7 @@ static dboolean             sound_initialized;
 
 static allocated_sound_t    *channels_playing[s_channels_max];
 
-static int                  mixer_freq;
+static int                  mixer_freq = MIX_DEFAULT_FREQUENCY;
 
 // Doubly-linked list of allocated sounds.
 // When a sound is played, it is moved to the head, so that the oldest sounds not used recently are at the tail.
@@ -435,7 +435,7 @@ dboolean I_InitSound(void)
         C_Warning(1, "The wrong version of <b>%s</b> was found. <i>%s</i> requires v%i.%i.%i.",
             SDL_MIXER_FILENAME, PACKAGE_NAME, SDL_MIXER_MAJOR_VERSION, SDL_MIXER_MINOR_VERSION, SDL_MIXER_PATCHLEVEL);
 
-    if (Mix_OpenAudioDevice(SAMPLERATE, MIX_DEFAULT_FORMAT, CHANNELS, CHUNKSIZE, NULL, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
+    if (Mix_OpenAudioDevice(SAMPLERATE, MIX_DEFAULT_FORMAT, CHANNELS, CHUNKSIZE, DEFAULT_DEVICE, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
         return false;
 
     if (!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -48,6 +48,13 @@
 #define CHUNKSIZE                   1024
 #define SAMPLERATE                  44100
 
+#if !defined(__HAIKU__)
+#define DEFAULT_DEVICE		    NULL
+#else
+// Triggers a segfault if no name is provided even tough the default device is empty
+#define DEFAULT_DEVICE		    ""
+#endif
+
 #define MAX_MUSIC_VOLUME            MIX_MAX_VOLUME
 #define MAX_SFX_VOLUME              MIX_MAX_VOLUME
 


### PR DESCRIPTION
Native media sound system of Haiku triggers segfault if NULL for the device name is provided.
Similarly, the mixer frequency needs a value before being set afterwards.