### PR TITLE
Fix for constant weapon fire on game load when clicking through menus

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -237,6 +237,7 @@ dboolean MouseShouldBeGrabbed(void)
 
 static void SetShowCursor(dboolean show)
 {
+	SDL_PumpEvents();
     SDL_SetRelativeMouseMode(!show);
     SDL_GetRelativeMouseState(NULL, NULL);
 }


### PR DESCRIPTION
Fix for issue #484 
When SDL_SetRelativeMouseMode is called mid-mouse click, the corresponding SDL_MOUSEBUTTONUP appears not to fire and it would behave as though mouse button 1 was stuck down. Calling SDL_PumpEvents beforehand appears to push the event through.