### PR TITLE
Populate translatekey table based on keyboard layout

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -237,7 +237,7 @@ static void SetShowCursor(dboolean show)
     SDL_GetRelativeMouseState(NULL, NULL);
 }
 
-static const int translatekey[] =
+static int translatekey[] =
 {
     0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
     's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', KEY_ENTER,
@@ -2153,6 +2153,14 @@ void I_InitGraphics(void)
     I_UpdateBlitFunc(false);
     memset(screens[0], nearestblack, SCREENAREA);
     blitfunc();
+
+    // Populate the scancode translation table for alphanum+punct
+    for (int k=4;k<=40;k++)
+      translatekey[k] = SDL_GetKeyFromScancode(k);
+    for (int k=45;k<=50;k++)
+      translatekey[k] = SDL_GetKeyFromScancode(k);
+    for (int k=51;k<=56;k++)
+      translatekey[k] = SDL_GetKeyFromScancode(k);
 
     I_Sleep(500);
 


### PR DESCRIPTION
In response to the discussion at #650 , this changes the `translatekey` array during `I_InitGraphics` to match the keyboard layout (at least on alphanumeric characters and bind-able punctuation). Tested to work on Debian 10 and Arch.

I believe it's something of a hack as the present system is too inflexible. Also something in the key-handling logic depends sensitively on one or more zeroes in that array, so we can't rewrite the whole thing according to the layout, hence the odd loop indices.

A full solution would involve dispensing with the current input handling method and maintaining instead an associative list of `SDLK_*` keycodes to values. I would understand rejecting this on these grounds.