### PR TITLE
fix potential heap corruption (calling free on string literal)

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -200,7 +200,7 @@ static char *GetRegistryString(registryvalue_t *reg_val)
     HKEY    key;
     DWORD   len = 0;
     DWORD   valtype;
-    char    *result = "";
+    char    *result = NULL;
 
     // Open the key (directory where the value is stored)
     if (RegOpenKeyEx(reg_val->root, reg_val->path, 0, KEY_READ, &key) != ERROR_SUCCESS)


### PR DESCRIPTION
doomretro was crashing on startup.
Exception code:0xc0000374 according to Event Viewer.
This PR fixes that problem.