### PR TITLE
Fix building on MacOS

### DIFF
--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -36,10 +36,10 @@
 #========================================================================
 #
 
-# [sneakernets] For macOS 32-bit and 64-bit
-OPTIMIZE = -O2 -m32
-CFLAGS = $(OPTIMIZE) -g `sdl-config --cflags` $(INCLUDES)
-LDFLAGS = -g `sdl-config --libs` -lSDL_mixer -lSDL2_image -framework CoreFoundation
+# [sneakernets] For macOS 64-bit
+OPTIMIZE = -O2 -m64
+CFLAGS = $(OPTIMIZE) $(INCLUDES) -ObjC -I/usr/local/include/SDL2
+LDFLAGS = -lSDL2 -lSDL2_mixer -lSDL2_image -lm -framework Foundation -framework Cocoa
 
 SRCS := $(shell find . -name '*.c')
 


### PR DESCRIPTION
64bit only since MacOS is no longer 32bit capable unless you run an older OS.  Long term support is not worth it.

I added the -ObjC flag because d_main is calling Cocoa.  Without this, the C compiler will attempt to read the header as a C header, not as an ObjC header.  This fixes the issue by telling the compiler to treat it as Objective C if it finds any headers that are in that language.