### PR TITLE
MacOS fix

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1719,10 +1719,11 @@ static void SetVideoMode(dboolean createwindow, dboolean output)
             {
                 refreshrate = displaymode.refresh_rate;
 
+#if !defined (__APPLE__)
                 if (vid_vsync == vid_vsync_adaptive && M_StringStartsWith(vid_scaleapi, "opengl"))
                     if (SDL_GL_SetSwapInterval(-1) < 0)
                         C_Warning(1, "Adaptive vsync is not supported.");
-
+#endif
                 if (refreshrate < vid_capfps || !vid_capfps)
                 {
                     I_CapFPS(0);


### PR DESCRIPTION
The latest release adds adaptive vsync, however in m_config.h this is not for MacOS:
```
#if defined(__APPLE__)
#define vid_vsync_min                           vid_vsync_off
#else
#define vid_vsync_min                           vid_vsync_adaptive
#endif
```

So this fix wraps the adaptive vsync in i_video.c to avoid compiling it on MacOS:
```
#if !defined (__APPLE__)
                if (vid_vsync == vid_vsync_adaptive && M_StringStartsWith(vid_scaleapi, "opengl"))
                    if (SDL_GL_SetSwapInterval(-1) < 0)
                        C_Warning(1, "Adaptive vsync is not supported.");
#endif
```