### PR TITLE
Fix compiler error in st_stuff.c

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1497,7 +1497,7 @@ static void ST_LoadUnloadGraphics(load_callback_t callback)
     callback("STFDEAD0", &faces[facenum]);
 
     // back screen
-    callback((gamemode == commercial ? "GRNROCK" : "FLOOR7_2"), &(patch_t *)grnrock);
+    callback((gamemode == commercial ? "GRNROCK" : "FLOOR7_2"), (patch_t **) &grnrock);
     callback("BRDR_T", &brdr_t);
     callback("BRDR_B", &brdr_b);
     callback("BRDR_L", &brdr_l);


### PR DESCRIPTION
The current master branch has an error in `st_stuff.c`. The code tries to take an address of a cast pointer, which is invalid.