### PR TITLE
Adding MinGW makefile

### DIFF
--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -1,0 +1,51 @@
+#
+#========================================================================
+#
+#                           D O O M  R e t r o
+#         The classic, refined DOOM source port. For Windows PC.
+#
+#========================================================================
+#
+#  Copyright © 1993-2022 by id Software LLC, a ZeniMax Media company.
+#  Copyright © 2013-2022 by Brad Harding <mailto:brad@doomretro.com>.
+#
+#  DOOM Retro is a fork of Chocolate DOOM. For a list of credits, see
+#  <https://github.com/bradharding/doomretro/wiki/CREDITS>.
+#
+#  This file is a part of DOOM Retro.
+#
+#  DOOM Retro is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation, either version 3 of the license, or (at your
+#  option) any later version.
+#
+#  DOOM Retro is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with DOOM Retro. If not, see <https://www.gnu.org/licenses/>.
+#
+#  DOOM is a registered trademark of id Software LLC, a ZeniMax Media
+#  company, in the US and/or other countries, and is used without
+#  permission. All other trademarks are the property of their respective
+#  holders. DOOM Retro is in no way affiliated with nor endorsed by
+#  id Software.
+#
+#========================================================================
+#
+
+# [gibbon] For MinGW
+CC = gcc
+CFLAGS = -D_WIN32 -DWIN_32_LEAN_AND_MEAN
+LDFLAGS = -Wl,-subsystem,windows -lmingw32 -lcomdlg32 -lwinmm -lgdi32 -lkernel32 -luser32 -lSDL2main -lSDL2 -lSDL2_mixer -lSDL2_image 
+
+SRCS = $(wildcard *.c)
+
+doomretro : $(SRCS)
+	windres win32.rc -O coff -o win32.res
+	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS) win32.res
+
+clean:
+	del doomretro


### PR DESCRIPTION
This allows Doom Retro to be compiled using MinGW on Windows.  Tested and Doom Retro functions just fine afterwards.