### PR TITLE
macos M_GetExecutableFolder bug fix proposal.

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2253,9 +2253,7 @@ static void D_DoomMainSetup(void)
     C_Output("All files created using the " BOLD("condump") " CCMD will be saved in "
         BOLD("%s" DIR_SEPARATOR_S "console" DIR_SEPARATOR_S) ".", appdatafolder);
 
-#if !defined(__APPLE__)
     free(appdatafolder);
-#endif
 
     // Check for -file in shareware
     if (modifiedgame)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -338,16 +338,16 @@ char *M_GetExecutableFolder(void)
         return exe;
     }
 #elif defined(__APPLE__)
-    char        *exe = malloc(MAX_PATH);
+    char        exe[MAX_PATH];
     uint32_t    len = MAX_PATH;
 
     if (_NSGetExecutablePath(exe, &len))
     {
         strcpy(exe, ".");
-        return exe;
+        return M_StringDuplicate(exe);
     }
 
-    return dirname(exe);
+    return M_StringDuplicate(dirname(exe));
 #elif defined(__HAIKU__)
     char    *exe = malloc(MAX_PATH);
 


### PR DESCRIPTION
data was allocated on the heap but the returned data weren't
 thus during IWAD data load it crashes (d_iwad part).