### PR TITLE
uaf fix for p_removebloodsplat.

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -905,8 +905,15 @@ void P_RemoveBloodMobj(mobj_t *mobj)
 void P_RemoveBloodSplats(void)
 {
     for (int i = 0; i < numsectors; i++)
-        for (bloodsplat_t *splat = sectors[i].splatlist; splat; splat = splat->next)
-            P_UnsetBloodSplatPosition(splat);
+    {
+	bloodsplat_t *splat = sectors[i].splatlist;
+	while (splat)
+	{
+		bloodsplat_t *next = splat->next;
+		P_UnsetBloodSplatPosition(splat);
+		splat = next;
+	}
+    }
 
     r_bloodsplats_total = 0;
 }


### PR DESCRIPTION
unfortunately the previous fix was not enough.
the next address on the linked list was lost
after P_UnsetBloodSplatPosition call.