### PR TITLE
FIX: build when using X11

### DIFF
--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -816,6 +816,10 @@ enum
     CDoor
 };
 
+#if defined(X11) && defined(AnyKey)
+#  undef AnyKey
+#endif
+
 // define names for the locked door Kind field of the general ceiling
 enum
 {


### PR DESCRIPTION
The problem occurs when trying to build a game using X11.
There is such a line in the X11/X.h file:
```c
/*****************************************************************
* RESERVED RESOURCE AND CONSTANT DEFINITIONS
*****************************************************************/
...
#define AnyKey     0L /* special Key Code, passed to GrabKey */
```

At the same time, in the doomretro code, there is the following enum in the p_spec.h file:
```c
// define names for the locked door Kind field of the general ceiling
enum
{
    AnyKey,
    ...
};
```

Include chain:
```text
i_video.c:37: #include <X11/Xlib.h>
    /usr/include/X11/Xlib.h:44: #include <X11/X.h>
i_video.c:55: #include "m_config.h"
    m_config.h:39: #include "p_local.h"
    p_local.h:341: #include "p_spec.h"
```

Therefore, a problem occurs when compiling i_video.c:
```text
cc -O2 -fsigned-char -g `sdl2-config --cflags` -DX11 -c i_video.c -o i_video.o
In file included from /usr/include/X11/Xlib.h:44,
                from i_video.c:37:
p_spec.h:822:5: error: expected identifier before numeric constant
822 |     AnyKey,
    |     ^~~~~~
make: *** [Makefile:55: i_video.o] Error 1
```

It is reproduced on many popular linux distributions.

One of the possible ways is to reproduce:
1. Use ubuntu docker container: `docker run -it ubuntu bash`;
2. Update list of available packages: `# apt update`;
3. Upgrade the system: `# apt upgrade -y`;
4. Install required packages: `# apt install -y git gcc make libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev`;
5. Clone doomretro repo: `$ git clone https://github.com/bradharding/doomretro`;
6. Enter source directory: `$ cd doomretro/src`;
7. Build i_video.c: `$ make i_video.o`.

Commands 2-4 and 5-7 can be combined into 2 commands:
1. `# apt update && apt upgrade -y && apt install -y git gcc make libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev`;
2. `$ git clone https://github.com/bradharding/doomretro && cd doomretro/src && make i_video.o`.
