### PR TITLE
Work-in progress support for compile-time render scale

### DIFF
--- a/src/c_console.c
+++ b/src/c_console.c
@@ -1587,7 +1587,7 @@ void C_Drawer(void)
     unsigned char   prevletter2 = '\0';
 
     // adjust console height
-    if (consolewait < tics)
+    if (consolewait < tics && consoleanim < CONSOLEDOWNSIZE)
     {
         consolewait = tics + (gamestate == GS_TITLESCREEN ? 4 : 8);
 
@@ -1595,14 +1595,14 @@ void C_Drawer(void)
         {
             if (consoleheight < CONSOLEHEIGHT)
             {
+                // [MP] in scale x2 coordinates
                 const int consoledown[CONSOLEDOWNSIZE] =
                 {
                      12,  29,  45,  60,  84,  97, 109, 120, 130, 139, 147, 154, 160, 165,
                     169, 173, 176, 179, 182, 184, 186, 188, 190, 192, 194, 194, 195, 195
                 };
 
-                const int   height = (gamestate == GS_TITLESCREEN ? consoledown[consoleanim] * 2 + 5 :
-                                consoledown[consoleanim]);
+                const int   height = (gamestate == GS_TITLESCREEN ? consoledown[consoleanim] * 2 + 5  : consoledown[consoleanim]) * SCALEMULTUNIT;
 
                 if (consoleheight > height)
                     consolewait = 0;
@@ -1618,13 +1618,14 @@ void C_Drawer(void)
         {
             if (consoleheight)
             {
+                // [MP] in scale x2 coordinates    
                 const int consoleup[CONSOLEUPSIZE] =
                 {
                     183, 167, 150, 133, 117, 100,  83,  67,  50,  33,  17,   0
                 };
 
-                const int   height = consoleup[consoleanim] * (gamestate == GS_TITLESCREEN ? 2 : 1);
-
+                const int   height = consoleup[consoleanim] * (gamestate == GS_TITLESCREEN ? 2 : 1) * SCALEMULTUNIT;
+		
                 if (consoleheight < height)
                     consolewait = 0;
                 else

--- a/src/c_console.h
+++ b/src/c_console.h
@@ -74,9 +74,9 @@
 #define CONSOLEDOWNSIZE                     28
 #define CONSOLEUPSIZE                       12
 
-#define CONSOLEHEIGHT                       ((gamestate == GS_TITLESCREEN ? SCREENHEIGHT : SCREENHEIGHT / 2) - 5)
+#define CONSOLEHEIGHT                       ((gamestate == GS_TITLESCREEN ? SCREENHEIGHT : SCREENHEIGHT / 2) - 5 * SCALEMULTUNIT)
 
-#define CONSOLELINES                        (gamestate == GS_TITLESCREEN ? 27 : 13)
+#define CONSOLELINES                        ((gamestate == GS_TITLESCREEN ? 27 : 13) * SCALEMULTUNIT)
 #define CONSOLETEXTX                        (vid_widescreen ? MAX(MAXWIDESCREENDELTA - 18, 10) : 10)
 #define CONSOLETEXTY                        8
 #define CONSOLETEXTMAXLENGTH                1024

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -67,7 +67,7 @@ void I_InitWindows32(void);
 #endif
 
 int                 SCREENWIDTH;
-int                 SCREENHEIGHT = VANILLAHEIGHT * 2;
+int                 SCREENHEIGHT = VANILLAHEIGHT * SCALEMULT;
 int                 SCREENAREA;
 int                 WIDESCREENDELTA;
 int                 MAXWIDESCREENDELTA;
@@ -79,7 +79,7 @@ bool                nowidescreen = false;
 bool                vid_widescreen_copy;
 
 int                 MAPWIDTH;
-int                 MAPHEIGHT = VANILLAHEIGHT * 2;
+int                 MAPHEIGHT = VANILLAHEIGHT * SCALEMULT;
 int                 MAPAREA;
 int                 MAPBOTTOM;
 
@@ -1851,7 +1851,7 @@ static void I_GetScreenDimensions(void)
         // r_fov * 0.82 is vertical FOV for 4:3 aspect ratio
         WIDEFOVDELTA = MIN((int)(atan(dest_rect.w / (dest_rect.h / tan(r_fov * 0.82 * M_PI / 360.0))) * 360.0 / M_PI) - r_fov - 2,
             MAXWIDEFOVDELTA);
-        WIDESCREENDELTA = SCREENWIDTH / 4 - VANILLAWIDTH / 2;
+        WIDESCREENDELTA = (SCREENWIDTH / SCALEMULT - VANILLAWIDTH) / 2;
         MAXWIDESCREENDELTA = MAX(53, WIDESCREENDELTA);
     }
     else

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -43,23 +43,38 @@
 
 #include "doomtype.h"
 
+// [MP] dont't change this
+#define DEFAULTSCALEMULT    2
+
+#ifndef SCALEMULT
+// [MP] Configurable compile-time render scale 
+// Valid values: 1, 2, 3, 4, 5, 6, 7, 8
+#define SCALEMULT           DEFAULTSCALEMULT
+#endif
+
+// [MP] The unit scale multiplier expressed in multiples of default 2x scale 
+// Used to convert coordinates expressed in 2x scale 
+// Not enclosed in parenthesis on purpose so fractional values (odd SCALEMULT) can be used
+// Must always used as last operand when multiplying by this value so it works with fractional values, ie: (expr) * SCALEMULTUNIT
+#define SCALEMULTUNIT       SCALEMULT / DEFAULTSCALEMULT
+
 // Screen width and height.
 #define VANILLAWIDTH        320
 #define VANILLAHEIGHT       200
 
 #define ACTUALVANILLAHEIGHT (VANILLAHEIGHT * 6 / 5)
-#define ACTUALHEIGHT        (ACTUALVANILLAHEIGHT * 2)
+#define ACTUALHEIGHT        (ACTUALVANILLAHEIGHT * SCALEMULT)
 
 #define VANILLASBARHEIGHT   32
-#define SBARHEIGHT          (VANILLASBARHEIGHT * 2)
+#define SBARHEIGHT          (VANILLASBARHEIGHT * SCALEMULT)
 
 #define WIDEVANILLAWIDTH    (ACTUALVANILLAHEIGHT * 16 / 9)
 
-#define NONWIDEWIDTH        (VANILLAWIDTH * 2)
+#define NONWIDEWIDTH        (VANILLAWIDTH * SCALEMULT)
 #define NONWIDEASPECTRATIO  (4.0 / 3.0)
 
 #define MAXWIDTH            (NONWIDEWIDTH * 6)
-#define MAXHEIGHT           ((VANILLAHEIGHT + 1) * 2)
+#define MAXHEIGHT           ((VANILLAHEIGHT + 1) * SCALEMULT)
 #define MAXSCREENAREA       (MAXWIDTH * MAXHEIGHT)
 
 #define MAXWIDEFOVDELTA     32

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -80,10 +80,10 @@
 #define ST_FACESX           (chex ? 144 : 143)
 #define ST_FACESY           168
 
-#define ST_FACEBACKX        (144 * 2 + WIDESCREENDELTA * 2)
-#define ST_FACEBACKY        (170 * 2)
-#define ST_FACEBACKWIDTH    (32 * 2)
-#define ST_FACEBACKHEIGHT   (29 * 2)
+#define ST_FACEBACKX        ((144 + WIDESCREENDELTA) * SCALEMULT)
+#define ST_FACEBACKY        (170 * SCALEMULT)
+#define ST_FACEBACKWIDTH    (32 * SCALEMULT)
+#define ST_FACEBACKHEIGHT   (29 * SCALEMULT)
 
 #define ST_EVILGRINCOUNT    (2 * TICRATE)
 #define ST_TURNCOUNT        (1 * TICRATE)
@@ -401,8 +401,9 @@ static void ST_RefreshBackground(void)
 {
     if (STBARs < 3 || ID1)
     {
-        if (r_detail == r_detail_high)
+        if (r_detail == r_detail_high && SCALEMULT == 2)
         {
+            // [MP] V_DrawBigPatch() requires a patch at 2x scale
             if (vid_widescreen)
             {
                 if (sbar2width < SCREENWIDTH)
@@ -421,7 +422,7 @@ static void ST_RefreshBackground(void)
             if (sbarwidth < SCREENWIDTH)
                 R_FillBezel();
 
-            V_DrawWidePatch((SCREENWIDTH / 2 - sbarwidth) / 2, VANILLAHEIGHT - VANILLASBARHEIGHT, 0, sbar);
+            V_DrawWidePatch((SCREENWIDTH / SCALEMULT - sbarwidth) / 2, VANILLAHEIGHT - VANILLASBARHEIGHT, 0, sbar);
 
             if (ammobg)
                 V_DrawWidePatch(ST_AMMOBGX, VANILLAHEIGHT - VANILLASBARHEIGHT, 0, ammobg);
@@ -432,7 +433,7 @@ static void ST_RefreshBackground(void)
         if (sbarwidth < SCREENWIDTH)
             R_FillBezel();
 
-        V_DrawWidePatch((SCREENWIDTH / 2 - sbarwidth) / 2, VANILLAHEIGHT - VANILLASBARHEIGHT, 0, sbar);
+        V_DrawWidePatch((SCREENWIDTH / SCALEMULT - sbarwidth) / 2, VANILLAHEIGHT - VANILLASBARHEIGHT, 0, sbar);
         V_DrawPatch((hacx ? ST_ARMSBGX + 4 : ST_ARMSBGX), VANILLAHEIGHT - VANILLASBARHEIGHT, 0, armsbg);
     }
 }
@@ -1742,8 +1743,9 @@ void ST_Init(void)
 {
     ST_LoadUnloadGraphics(&ST_LoadCallback);
 
-    st_drawbrdr = (lumpinfo[W_GetNumForName("BRDR_B")]->wadfile->type == PWAD
-        || lumpinfo[W_GetNumForName(gamemode == commercial ? "GRNROCK" : "FLOOR7_2")]->wadfile->type == IWAD);
+    st_drawbrdr = SCALEMULT == 2 &&
+        ((lumpinfo[W_GetNumForName("BRDR_B")]->wadfile->type == PWAD
+          || lumpinfo[W_GetNumForName(gamemode == commercial ? "GRNROCK" : "FLOOR7_2")]->wadfile->type == IWAD));
 
     // [BH] fix evil grin being displayed when picking up first item after
     // loading save game or entering IDFA/IDKFA cheat
@@ -1754,7 +1756,7 @@ void ST_Init(void)
     if (gamemode == shareware)
         maxammo[am_cell] = 0;
 
-    usesmallnums = ((!STYSNUM0 && STBARs == 2 && !harmony) || gamemode == shareware || ID1);
+    usesmallnums = SCALEMULT == 2 && ((!STYSNUM0 && STBARs == 2 && !harmony) || gamemode == shareware || ID1);
 
     STLib_Init();
     ST_InitCheats();


### PR DESCRIPTION
This PR adds work-in progress support for configurable render scale at compile-time to allow 1, 2, 3, 4, ... 8x scaling. The default still being 2 of course.

This is done via the `SCALEMULT` define. For example to generate a binary with 4x scaling:

```
cmake -DCMAKE_C_FLAGS="-DSCALEMULT=4" .
```

- scaled:
  - graphics
  - menus
  - status bar (uses 1x SBAR patch if SCALEMULT != 2)

- not scaled (elements are displayed smaller than at the default 2x scale)
  - console
  - fullscreen HUD
  - user messages displayed in top left corner
  - fake lighting (see below)
  - startup logo (shrinked)
  - green background texture with smaller window size
  - possibly more

Ideally all UI elements should be scaled so they are displayed at the same size than the default 2x scale. 
It would require much more work though and for this initial version I went for simplicity not scaling them.
At 6x scale some of these elements become very small and hard to read but at 4x scale it is OK.
At 1x scale they are too big.

There is an issue with the fake lighting still hard-coded to 2x scale. It looks wrong with other scales (too bright with scale > 2, too dark with scale = 1). I look a bit into the rendering code but it very complex and did not understand what to modify to make it work at other scales. What happens is that the lighting is always applied to 400 lines (ie the 2x scale height) centered to the screen. That is, for 4x scale (height=800), it is applied between lines 200 and 600 instead of the whole height. This can be seen easily comparing screenshots at scale 2x and 4x with `r_textures 0`.  


Scale 1x is more of a bonus than anything but it is amusing to have it to make it look even more retro (but with widescreen if you want it).

- Issues at scale 1x:
  - startup logo is drawn truncated because logo patch is 2x
  - fullscreen HUD is too big
  - user messages are too big
  - console font designed for 2x is too big (but still usable)


Given the amount of configuration settings, I probably have missed some minor stuff that is still hard-coded to 2x.