### PR TITLE
Id24 colormaps

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -2237,8 +2237,14 @@ static void P_LoadSideDefs2(int lump)
                     sec->topmap = 0, R_TextureNumForName(msd->toptexture) : 0);
                 break;
 
-            // kln 04/13/25: load the colormap for the id24 line special: 2075: Set the target sector's colormap (Always)
+            // kln 04/13/25: load the colormap for the id24 line specials: 2075 - 2081: Set the target sector's colormap
             case SetTheTargetSectorsColormap:
+            case W1_SetTheTargetSectorsColormap:
+            case WR_SetTheTargetSectorsColormap:
+            case S1_SetTheTargetSectorsColormap:
+            case SR_SetTheTargetSectorsColormap:
+            case G1_SetTheTargetSectorsColormap:
+            case GR_SetTheTargetSectorsColormap:
                 sd->toptexture = ((sd->id24colormapindex = R_ColormapNumForName(msd->toptexture)) < 0 ?
                     sd->id24colormapindex = 0, R_TextureNumForName(msd->toptexture) : 0);
                 sd->midtexture = R_TextureNumForName(msd->midtexture);

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -2237,6 +2237,17 @@ static void P_LoadSideDefs2(int lump)
                     sec->topmap = 0, R_TextureNumForName(msd->toptexture) : 0);
                 break;
 
+            // kln 04/13/25: load the colormap for the id24 line special: 2075: Set the target sector's colormap (Always)
+            case SetTheTargetSectorsColormap:
+                sd->toptexture = ((sd->id24colormapindex = R_ColormapNumForName(msd->toptexture)) < 0 ?
+                    sd->id24colormapindex = 0, R_TextureNumForName(msd->toptexture) : 0);
+                sd->midtexture = R_TextureNumForName(msd->midtexture);
+                sd->missingmidtexture = (R_CheckTextureNumForName(msd->midtexture) == -1);
+                sd->bottomtexture = R_TextureNumForName(msd->bottomtexture);
+                sd->missingbottomtexture = (R_CheckTextureNumForName(msd->bottomtexture) == -1);
+
+                break;
+
             case Translucent_MiddleTexture:
                 // killough 04/11/98: apply translucency to 2s normal texture
                 sd->midtexture = (strncasecmp("TRANMAP", msd->midtexture, 8) ?

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1313,6 +1313,13 @@ bool P_CheckTag(const line_t *line)
         case SR_Teleport_AlsoMonsters_Silent_SameAngle:
         case Scroll_ScrollWallUsingSidedefOffsets:
         case Translucent_MiddleTexture:
+        case SetTheTargetSectorsColormap:
+        case W1_SetTheTargetSectorsColormap:
+        case WR_SetTheTargetSectorsColormap:
+        case S1_SetTheTargetSectorsColormap:
+        case SR_SetTheTargetSectorsColormap:
+        case G1_SetTheTargetSectorsColormap:
+        case GR_SetTheTargetSectorsColormap:
             return true;    // zero tag allowed
     }
 

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -2114,6 +2114,23 @@ void P_CrossSpecialLine(line_t *line, const int side, mobj_t *thing, const bool 
                 EV_SilentTeleport(line, side, thing);
 
             break;
+            
+        // id24 specials
+            
+        // kln 04/13/25 support for the id24 spec "set target" colormap 2076 (W1)
+        case W1_SetTheTargetSectorsColormap:
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+            line->special = 0;
+
+            break;
+
+        // kln 04/13/25 support for the id24 spec "set target" colormap 2077 (WR)
+        case WR_SetTheTargetSectorsColormap:
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+
+            break;
     }
 }
 
@@ -2262,6 +2279,25 @@ void P_ShootSpecialLine(const mobj_t *thing, line_t *line)
 
             P_ChangeSwitchTexture(line, false);
             G_SecretExitLevel();
+            break;
+
+
+            // id24 specials
+           
+        case G1_SetTheTargetSectorsColormap:
+            // kln 04/13/25 support for the id24 spec "set target" colormap 2080 (G1)
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+            line->special = 0;
+
+            break;
+
+            
+        case GR_SetTheTargetSectorsColormap:
+            // kln 04/13/25 support for the id24 spec "set target" colormap 2081 (GR)
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+
             break;
     }
 }

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -2288,7 +2288,8 @@ void P_ShootSpecialLine(const mobj_t *thing, line_t *line)
             // kln 04/13/25 support for the id24 spec "set target" colormap 2080 (G1)
             for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
                 sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
-            line->special = 0;
+            P_ChangeSwitchTexture(line, false);
+            
 
             break;
 
@@ -2297,6 +2298,7 @@ void P_ShootSpecialLine(const mobj_t *thing, line_t *line)
             // kln 04/13/25 support for the id24 spec "set target" colormap 2081 (GR)
             for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
                 sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+            P_ChangeSwitchTexture(line, true);
 
             break;
     }

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -54,7 +54,7 @@
 #include "sc_man.h"
 #include "w_wad.h"
 #include "z_zone.h"
-#include "r_defs.h"
+
 
 const bool islightspecial[] =
 {

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -54,6 +54,7 @@
 #include "sc_man.h"
 #include "w_wad.h"
 #include "z_zone.h"
+#include "r_defs.h"
 
 const bool islightspecial[] =
 {
@@ -2701,6 +2702,16 @@ void P_SpawnSpecials(void)
                     sectors[s].heightsec = sec;
 
                 break;
+            }
+
+            // kln 04/13/25: Support for the id24 line special 2075: Set the target sector's colormap (Always)
+            // uses a new SHORT in side_t, which is loaded via P_LoadSideDefs2
+            case SetTheTargetSectorsColormap:
+            {
+                for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                    sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+
+                    break;
             }
 
             // killough 03/16/98: Add support for setting floor lighting independently (e.g. lava)

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -1101,7 +1101,7 @@ bool P_UseSpecialLine(mobj_t *thing, line_t *line, const int side, const bool bo
             for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
                 sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
             P_ChangeSwitchTexture(line, false);
-            line->special = 0;
+            
 
             return true;
 

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -1093,6 +1093,26 @@ bool P_UseSpecialLine(mobj_t *thing, line_t *line, const int side, const bool bo
                 S_StartSound(thing, sfx_noway);
 
             return true;
+
+            // id24 specials
+
+        case S1_SetTheTargetSectorsColormap:
+            // kln 04/13/25 support for the id24 spec "set target" colormap 2078 (S1)
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+            P_ChangeSwitchTexture(line, false);
+            line->special = 0;
+
+            return true;
+
+
+        case SR_SetTheTargetSectorsColormap:
+            // kln 04/13/25 support for the id24 spec "set target" colormap 2079 (SR)
+            for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0; )
+                sectors[s].id24colormap = sides[*line->sidenum].id24colormapindex;
+            P_ChangeSwitchTexture(line, true);
+
+            return true;
     }
 
     return !bossaction;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -192,6 +192,9 @@ typedef struct sector_s
     int                 midmap;
     int                 topmap;
 
+    // KLN 04/06/25: colormap for id24 spec
+    int                 id24colormap;
+
     // killough 08/28/98: friction is a sector property, not an mobj property.
     // these fields used to be in mobj_t, but presented performance problems
     // when processed as mobj properties. Fix is to make them sector properties.
@@ -229,6 +232,9 @@ typedef struct
     short               toptexture;
     short               bottomtexture;
     short               midtexture;
+
+    // id24 colormap index
+    short               id24colormapindex;
 
     // Sector the SideDef is facing.
     sector_t            *sector;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -1112,6 +1112,15 @@ static void R_SetupFrame(void)
             colormap = 0;
     }
 
+    // kln 04/13/25 id24 colormap rendering (line specials 2075 - 2081)
+    if (mo->subsector->sector->id24colormap)
+    {
+
+        colormap = mo->subsector->sector->id24colormap;
+        if (colormap < 0 || colormap > numcolormaps)
+            colormap = 0;
+    }
+
     fullcolormap = colormaps[colormap];
     zlight = c_zlight[colormap];
     scalelight = c_scalelight[colormap];


### PR DESCRIPTION
Tested in both my own test WAD and boomtest, works under the use-cases I've tried so far without issue. Does *not* override player colormaps (damage, powerups) as per spec, overrides other colormaps like transfer heights as per spec, and defaults to the normal colormap (or whatever transfer colormap is active via line 242) if the colormap is invalid.