### PR TITLE
adding -fwrapv to unix compilers for known (signed integer) overflow …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ ENDIF()
 
 IF (UNIX)
 	INCLUDE(CheckCCompilerFlag)
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -fwrapv")
 	CHECK_C_COMPILER_FLAG("-Wno-deprecated-non-prototype" HAS_NON_PROTO_FLAG)
 	IF (HAS_NON_PROTO_FLAG)
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-non-prototype")


### PR DESCRIPTION
…cases

typical case:

```
doomretro/src/p_mobj.c:1345:80: runtime error: signed integer overflow: 536870912 * 6 cannot be represented in type 'int'
```
which can't be "fixed" since the games behavior rely on this behavior.