### PR TITLE
M_GetAppDataFolder/M_GetResourceFolder macOS fix proposal. returning …

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -271,7 +271,7 @@ char *M_GetAppDataFolder(void)
 
         closedir(resourcedir);
 
-        return (char *)appSupportURL.fileSystemRepresentation;
+        return strdup((char *)appSupportURL.fileSystemRepresentation);
 #else
         // On Linux, store generated application files in /home/<username>/.config/doomretro
         char    *buffer = getenv("HOME");
@@ -316,9 +316,11 @@ char *M_GetResourceFolder(void)
 #if defined(__APPLE__)
     // On macOS, load resources from the Contents/Resources folder within the application bundle
     // if ../share/doomretro is not available.
+    closedir(resourcedir);
+    free(executablefolder);
     NSURL   *resourceURL = [NSBundle mainBundle].resourceURL;
 
-    return (char *)resourceURL.fileSystemRepresentation;
+    return strdup((char *)resourceURL.fileSystemRepresentation);
 #else
     free(resourcefolder);
     // And on Linux, fall back to the same folder as the executable.


### PR DESCRIPTION
…a heap copy via strdup to avoid freeing an ObjC runtime managed pointer. Also fixing executablefolder/resourcefolder leaks in M_GetResourceFolder.