### PR TITLE
Fix resource leaks and incorrect memset sizes

### DIFF
--- a/src/c_console.c
+++ b/src/c_console.c
@@ -3171,8 +3171,9 @@ bool C_Responder(event_t *ev)
                     char    buffer[255];
                     char    *temp1 = M_SubString(consoleinput, 0, selectstart);
                     char    *temp2 = M_SubString(consoleinput, selectend, (size_t)len - selectend);
+                    char    *clipboard = SDL_GetClipboardText();
 
-                    M_snprintf(buffer, sizeof(buffer), "%s%s%s", temp1, SDL_GetClipboardText(), temp2);
+                    M_snprintf(buffer, sizeof(buffer), "%s%s%s", temp1, clipboard, temp2);
                     M_StringCopy(buffer, M_StringReplaceFirst(buffer, "(null)", ""), sizeof(buffer));
                     M_StringCopy(buffer, M_StringReplaceFirst(buffer, "(null)", ""), sizeof(buffer));
 
@@ -3180,12 +3181,13 @@ bool C_Responder(event_t *ev)
                     {
                         C_AddToUndoHistory();
                         M_StringCopy(consoleinput, buffer, sizeof(consoleinput));
-                        selectstart += (int)strlen(SDL_GetClipboardText());
+                        selectstart += (int)strlen(clipboard);
                         selectend = caretpos = selectstart;
                     }
 
                     free(temp1);
                     free(temp2);
+                    SDL_free(clipboard);
                 }
 
                 break;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -445,6 +445,10 @@ static void I_GetEvent(void)
                 ev.data1 = (text[0] ? text[0] : Event->text.text[strlen(Event->text.text) - 1]);
                 ev.type = ev_textinput;
                 D_PostEvent(&ev);
+
+                if (text)
+                    SDL_free(text);
+
                 break;
             }
 

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -1423,8 +1423,8 @@ void R_InitBuffer(void)
     fuzzrange[1] = 0;
     fuzzrange[2] = SCREENWIDTH * 2;
 
-    memset(fuzz1table, 0, MAXSCREENAREA);
-    memset(fuzz2table, 0, MAXSCREENAREA);
+    memset(fuzz1table, 0, MAXSCREENAREA * sizeof(int));
+    memset(fuzz2table, 0, MAXSCREENAREA * sizeof(int));
 
     for (int i = 0; i < 256; i++)
         flipindex[i] = (i < 128 ? i : 126 - (i & 127));


### PR DESCRIPTION
- Fix SDL clipboard text leaked twice per paste in console (c_console.c)
- Fix SDL_iconv_utf8_ucs4 result leaked on every text input event (i_video.c)
- Fix fuzz tables only 1/4 cleared due to missing sizeof(int) in memset (r_draw.c)