### PR TITLE
p_doors: guard against one-sided line in EV_VerticalDoor

### DIFF
--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -500,9 +500,9 @@ void EV_VerticalDoor(line_t *line, mobj_t *thing)
     vldoor_t    *door;
 
     // if the wrong side of door is pushed, give oof sound
-    if (line->sidenum[1] == NO_INDEX && player)     // killough
+    if (line->sidenum[1] == NO_INDEX)     // killough
     {
-        if (!autousing && P_DoorClosed(line))
+        if (player && !autousing && P_DoorClosed(line))
             S_StartSound(player->mo, sfx_noway);    // [BH] use sfx_noway instead of sfx_oof
 
         return;


### PR DESCRIPTION
Prevents OOB read of sides[NO_INDEX] when a monster activates a DR_Door_OpenWaitClose_AlsoMonsters special placed on a one-sided line.